### PR TITLE
fix: enforce 0755 on ctx COPY to prevent Permission Denied in CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 # Allow build scripts to be referenced without being copied into the final image
 ARG BASE_IMAGE=localhost/kyth-base:stable
 FROM scratch AS ctx
-COPY build_files /
+# --chmod=0755 ensures scripts are executable regardless of git core.fileMode
+# settings in CI (actions/checkout with core.fileMode=false strips the execute
+# bit, causing a Permission Denied when the bind-mounted ctx layer is rebuilt
+# after a cache miss).
+COPY --chmod=0755 build_files /
 
 # Base Image
 ARG BASE_IMAGE


### PR DESCRIPTION
actions/checkout sets core.fileMode=false by default, which strips the execute bit from checked-out files. When a cache miss forces a ctx layer rebuild (e.g. after sysconfig.sh is modified), the freshly COPYed files land as 0644 and the bind-mounted script cannot be executed. Previously cached layers were unaffected because they never re-ran the COPY.

Adding --chmod=0755 to the COPY instruction guarantees all build scripts in the ctx stage are always executable, regardless of the checkout environment's fileMode setting.

https://claude.ai/code/session_01CPPmwep2o7tLvi178euDcQ