### PR TITLE
Bake VS Code native RPM into image instead of Flatpak

### DIFF
--- a/build_files/just/kyth.just
+++ b/build_files/just/kyth.just
@@ -598,13 +598,6 @@ setup-kyth-dev-box:
         exit 1
     fi
 
-    if ! flatpak info com.visualstudio.code >/dev/null 2>&1; then
-        echo "VS Code not found. Installing com.visualstudio.code from Flathub..."
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        flatpak install -y flathub com.visualstudio.code
-    else
-        echo "VS Code already installed."
-    fi
     kyth-vscode-wallet
 
     if distrobox list --no-color 2>/dev/null | grep -q "^${box}\b"; then
@@ -620,18 +613,16 @@ setup-kyth-dev-box:
     distrobox enter "${box}" -- sudo dnf install -y "${packages[@]}"
     echo
     echo "Done. Enter it with: distrobox enter ${box}"
-    echo "VS Code launch command: flatpak run com.visualstudio.code"
+    echo "VS Code launch command: code"
 
-# Install VS Code as a Flatpak instead of baking the Microsoft RPM into KythOS.
+# Configure VS Code KWallet integration (VS Code is baked into the image).
 [group('KythOS')]
 install-vscode:
     #!/usr/bin/env bash
     set -euo pipefail
-    flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-    flatpak install -y flathub com.visualstudio.code
     kyth-vscode-wallet
     echo
-    echo "VS Code installed. Launch it from the app menu."
+    echo "VS Code is baked into the image. Launch it from the app menu or run: code"
 
 # Set up Waydroid (Android in a container) on KythOS.
 #

--- a/build_files/kyth-vscode-wallet
+++ b/build_files/kyth-vscode-wallet
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-app_id="com.visualstudio.code"
+# Configure VS Code to use KWallet6 for secret storage.
+# Native RPM installs use ~/.config/Code/argv.json.
 
 write_argv() {
     local path="$1"
@@ -33,26 +34,6 @@ EOF
     fi
 }
 
-# VS Code has used both locations across Linux package variants. Writing both is
-# harmless, and keeps the Flatpak from missing the runtime argument after install.
-write_argv "${HOME}/.var/app/${app_id}/config/Code/argv.json"
-write_argv "${HOME}/.var/app/${app_id}/config/Code/User/argv.json"
-
-if [[ "${KYTH_VSCODE_WALLET_SKIP_FLATPAK:-0}" != "1" ]] \
-    && command -v flatpak >/dev/null 2>&1; then
-    flatpak override --user \
-        --talk-name=org.kde.kwalletd5 \
-        --talk-name=org.kde.kwalletd6 \
-        --talk-name=org.freedesktop.secrets \
-        "${app_id}" >/dev/null
-else
-    mkdir -p "${HOME}/.local/share/flatpak/overrides"
-    cat > "${HOME}/.local/share/flatpak/overrides/${app_id}" <<'EOF'
-[Session Bus Policy]
-org.kde.kwalletd5=talk
-org.kde.kwalletd6=talk
-org.freedesktop.secrets=talk
-EOF
-fi
+write_argv "${HOME}/.config/Code/argv.json"
 
 echo "VS Code wallet integration configured for ${USER:-this user}."

--- a/build_files/kyth-welcome/kyth-welcome
+++ b/build_files/kyth-welcome/kyth-welcome
@@ -7525,11 +7525,8 @@ def _is_distrobox_container(name: str) -> bool:
 _INSTALL_VSCODE_CMD = [
     "bash", "-c",
     "set -euo pipefail\n"
-    "flatpak remote-add --if-not-exists flathub "
-    "https://dl.flathub.org/repo/flathub.flatpakrepo\n"
-    "flatpak install --noninteractive -y flathub com.visualstudio.code\n"
     "kyth-vscode-wallet\n"
-    "echo 'VS Code installed. Launch it from the application menu.'",
+    "echo 'VS Code is baked into the image. KWallet integration configured.'",
 ]
 
 _SETUP_DEV_BOX_CMD = [
@@ -7549,15 +7546,6 @@ if ! command -v distrobox >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! flatpak info com.visualstudio.code >/dev/null 2>&1; then
-    echo "VS Code not found — installing from Flathub..."
-    flatpak remote-add --if-not-exists flathub \
-        https://dl.flathub.org/repo/flathub.flatpakrepo
-    flatpak install --noninteractive -y flathub com.visualstudio.code
-    echo "VS Code installed."
-else
-    echo "VS Code already installed."
-fi
 kyth-vscode-wallet
 
 if distrobox list --no-color 2>/dev/null | grep -q "^${box}\b"; then
@@ -8785,9 +8773,9 @@ class SoftwarePage(Page):
         dev_title.setObjectName("card-title")
         dev_layout.addWidget(dev_title)
         dev_body = QLabel(
-            "Set up the tools used to work on KythOS without baking the whole "
-            "development stack into the base image. VS Code installs as a Flatpak; "
-            "build and repo tools live in a Fedora distrobox named kyth-dev."
+            "Set up the tools used to work on KythOS. VS Code is baked into the "
+            "image with full local filesystem and terminal access. Build and repo "
+            "tools live in a Fedora distrobox named kyth-dev."
         )
         dev_body.setObjectName("card-copy")
         dev_body.setWordWrap(True)
@@ -8798,9 +8786,9 @@ class SoftwarePage(Page):
         ))
         dev_btn_row = QHBoxLayout()
         dev_btn_row.setSpacing(10)
-        dev_code_btn = QPushButton("Install VS Code")
+        dev_code_btn = QPushButton("Configure VS Code")
         dev_code_btn.clicked.connect(
-            lambda: self._run_dev_command(_INSTALL_VSCODE_CMD, "Installing VS Code…")
+            lambda: self._run_dev_command(_INSTALL_VSCODE_CMD, "Configuring VS Code…")
         )
         dev_btn_row.addWidget(dev_code_btn)
         dev_box_btn = QPushButton("Create Dev Box")

--- a/build_files/scripts/packages.sh
+++ b/build_files/scripts/packages.sh
@@ -385,6 +385,23 @@ ln -sf /usr/lib/systemd/system/graphical.target \
     /etc/systemd/system/default.target
 
 
+# ── VS Code ───────────────────────────────────────────────────────────────────
+# Bake VS Code native RPM into the image so it has full access to the local
+# filesystem and terminal without the sandboxing constraints of a Flatpak.
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+cat > /etc/yum.repos.d/vscode.repo <<'EOF'
+[code]
+name=Visual Studio Code
+baseurl=https://packages.microsoft.com/yumrepos/vscode
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+EOF
+dnf5 install -y code
+# Disable so the Microsoft repo is not active in the running OS;
+# VS Code self-updates are not meaningful in an immutable image.
+dnf5 config-manager setopt code.enabled=0
+
 # Remove dnf transaction history and repo solver data from the image layer.
 # The download cache is already excluded via --mount=type=cache in the
 # Dockerfile, but /var/lib/dnf/ is not on a cache mount and accumulates

--- a/build_files/scripts/sysconfig.sh
+++ b/build_files/scripts/sysconfig.sh
@@ -496,10 +496,10 @@ DefaultLimitNOFILE=1048576' > /etc/systemd/system.conf.d/99-kyth-limits.conf
 echo '[Manager]
 DefaultLimitNOFILE=1048576' > /etc/systemd/user.conf.d/99-kyth-limits.conf
 
-# ── VS Code Flatpak: KWallet keyring integration ─────────────────────────────
-# Seed new users with the same config that kyth-vscode-wallet applies to
-# existing users when they install VS Code from Welcome or ujust.
-HOME=/etc/skel KYTH_VSCODE_WALLET_SKIP_FLATPAK=1 /ctx/kyth-vscode-wallet
+# ── VS Code: KWallet keyring integration ─────────────────────────────────────
+# Seed new users with argv.json pointing at kwallet6 so VS Code never prompts
+# for a keychain password on first launch.
+HOME=/etc/skel /ctx/kyth-vscode-wallet
 
 # ── Baloo file indexer — disabled by default ─────────────────────────────────
 # Baloo (KDE's file indexer) runs heavy I/O scans on first boot and after game


### PR DESCRIPTION
Switches VS Code from a Flatpak installation to a native RPM baked directly into the KythOS image. This gives VS Code full access to the local filesystem and terminal without sandboxing constraints.

## Key Changes

- **packages.sh**: Added Microsoft's VS Code RPM repository and installed the native `code` package during image build. Disabled the repo post-install since self-updates aren't meaningful in an immutable image.

- **kyth-vscode-wallet**: Simplified to configure only the native RPM install location (`~/.config/Code/argv.json`). Removed all Flatpak-specific logic including Flatpak overrides and the dual-path argv.json writes.

- **kyth-welcome**: Updated the VS Code installation flow to only run `kyth-vscode-wallet` (KWallet integration) since VS Code is now pre-installed. Changed UI text and button labels from "Install VS Code" to "Configure VS Code" and updated descriptions to reflect that VS Code is baked into the image.

- **kyth.just**: Removed Flatpak installation checks and commands from both `setup-kyth-dev-box` and `install-vscode` recipes. Updated launch instructions to use the native `code` command instead of `flatpak run com.visualstudio.code`.

- **sysconfig.sh**: Simplified the skeleton user setup by removing the `KYTH_VSCODE_WALLET_SKIP_FLATPAK` flag (no longer needed) and updated comments to reflect native RPM configuration.

## Implementation Details

The native RPM approach provides better integration with the host system while maintaining KWallet6 keyring support through the existing `kyth-vscode-wallet` configuration script. Users get VS Code pre-configured on first boot without additional installation steps.

https://claude.ai/code/session_01L8gBq5R54uQxfGnKveP9KE