### PR TITLE
[codex] add required repository validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,147 @@
+name: Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+      - testing
+  push:
+    branches:
+      - main
+      - testing
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ACTIONLINT_VERSION: 1.7.7
+  HADOLINT_VERSION: 2.14.0
+
+jobs:
+  validation:
+    name: validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pinned validators
+        run: |
+          set -euo pipefail
+          bin_dir="${RUNNER_TEMP}/bin"
+          download_dir="${RUNNER_TEMP}/validator-downloads"
+          mkdir -p "${bin_dir}" "${download_dir}"
+
+          actionlint_archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          actionlint_base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+          curl --fail --location --silent --show-error \
+            --output "${download_dir}/${actionlint_archive}" \
+            "${actionlint_base}/${actionlint_archive}"
+          curl --fail --location --silent --show-error \
+            --output "${download_dir}/actionlint_checksums.txt" \
+            "${actionlint_base}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          (
+            cd "${download_dir}"
+            grep " ${actionlint_archive}$" actionlint_checksums.txt | sha256sum --check --strict -
+            tar -xzf "${actionlint_archive}" actionlint
+          )
+          install -m 0755 "${download_dir}/actionlint" "${bin_dir}/actionlint"
+
+          hadolint_binary="hadolint-linux-x86_64"
+          hadolint_base="https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}"
+          curl --fail --location --silent --show-error \
+            --output "${download_dir}/${hadolint_binary}" \
+            "${hadolint_base}/${hadolint_binary}"
+          curl --fail --location --silent --show-error \
+            --output "${download_dir}/${hadolint_binary}.sha256" \
+            "${hadolint_base}/${hadolint_binary}.sha256"
+          (
+            cd "${download_dir}"
+            sha256sum --check --strict "${hadolint_binary}.sha256"
+          )
+          install -m 0755 "${download_dir}/${hadolint_binary}" "${bin_dir}/hadolint"
+          echo "${bin_dir}" >> "${GITHUB_PATH}"
+
+      - name: Validate GitHub Actions workflows
+        run: actionlint -color -shellcheck=""
+
+      - name: Validate container build files
+        run: |
+          hadolint --failure-threshold error \
+            Dockerfile \
+            build_base/Dockerfile \
+            build_base/Containerfile.docker-overlay \
+            installer/Containerfile
+
+      - name: Validate shell scripts
+        run: |
+          set -euo pipefail
+          shell_files=()
+          while IFS= read -r -d '' file; do
+            mime_type="$(file --brief --mime-type "${file}")"
+            if [[ "${mime_type}" == "text/x-shellscript" ]]; then
+              shell_files+=("${file}")
+            fi
+          done < <(git ls-files -z)
+
+          if (( ${#shell_files[@]} == 0 )); then
+            echo "No shell scripts found"
+            exit 1
+          fi
+
+          printf 'Checking %d shell scripts\n' "${#shell_files[@]}"
+          shellcheck --severity=error "${shell_files[@]}"
+          for file in "${shell_files[@]}"; do
+            bash -n "${file}"
+          done
+
+      - name: Validate Python syntax
+        run: |
+          python3 - <<'PY'
+          import ast
+          import subprocess
+          from pathlib import Path
+
+          files = subprocess.check_output(
+              ["git", "ls-files", "*.py"], text=True
+          ).splitlines()
+          for name in files:
+              path = Path(name)
+              ast.parse(path.read_text(encoding="utf-8"), filename=name)
+          print(f"Checked {len(files)} Python files")
+          PY
+
+      - name: Validate structured configuration
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' file; do
+            jq empty "${file}"
+          done < <(git ls-files -z '*.json')
+
+          python3 - <<'PY'
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          files = subprocess.check_output(
+              ["git", "ls-files", "*.toml"], text=True
+          ).splitlines()
+          for name in files:
+              with Path(name).open("rb") as stream:
+                  tomllib.load(stream)
+          print(f"Checked {len(files)} TOML files")
+          PY
+
+      - name: Validate systemd units
+        run: systemd-analyze verify build_files/*.service build_files/*.timer
+
+      - name: Validate Just recipes
+        run: |
+          set -euo pipefail
+          just --list >/dev/null
+          while IFS= read -r -d '' file; do
+            just --justfile "${file}" --list >/dev/null
+          done < <(git ls-files -z '*.just')

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -136,7 +136,23 @@ jobs:
           PY
 
       - name: Validate systemd units
-        run: systemd-analyze verify build_files/*.service build_files/*.timer
+        run: |
+          set -euo pipefail
+          output="$(systemd-analyze verify build_files/*.service build_files/*.timer 2>&1 || true)"
+          printf '%s\n' "${output}"
+
+          # The Ubuntu runner does not contain commands installed into the
+          # finished KythOS image. Keep every other verifier diagnostic fatal.
+          unexpected="$(printf '%s\n' "${output}" \
+            | grep -Ev \
+              -e '^[^:]+: Command .+ is not executable: No such file or directory$' \
+              -e '^Failed to turn off SO_PASSRIGHTS on user lookup socket, ignoring: Operation not permitted$' \
+              -e '^Failed to enable SO_PASSCRED on handoff timestamp socket: Operation not permitted$' \
+            || true)"
+          if [[ -n "${unexpected}" ]]; then
+            printf 'Unexpected systemd verification errors:\n%s\n' "${unexpected}" >&2
+            exit 1
+          fi
 
       - name: Validate Just recipes
         run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,6 +17,7 @@ permissions:
 env:
   ACTIONLINT_VERSION: 1.7.7
   HADOLINT_VERSION: 2.14.0
+  JUST_VERSION: 1.52.0
 
 jobs:
   validation:
@@ -63,6 +64,21 @@ jobs:
             sha256sum --check --strict "${hadolint_binary}.sha256"
           )
           install -m 0755 "${download_dir}/${hadolint_binary}" "${bin_dir}/hadolint"
+
+          just_archive="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          just_base="https://github.com/casey/just/releases/download/${JUST_VERSION}"
+          curl --fail --location --silent --show-error \
+            --output "${download_dir}/${just_archive}" \
+            "${just_base}/${just_archive}"
+          curl --fail --location --silent --show-error \
+            --output "${download_dir}/just_checksums.txt" \
+            "${just_base}/SHA256SUMS"
+          (
+            cd "${download_dir}"
+            grep " ${just_archive}$" just_checksums.txt | sha256sum --check --strict -
+            tar -xzf "${just_archive}" just
+          )
+          install -m 0755 "${download_dir}/just" "${bin_dir}/just"
           echo "${bin_dir}" >> "${GITHUB_PATH}"
 
       - name: Validate GitHub Actions workflows


### PR DESCRIPTION
## What changed

- Add a fast repository validation workflow for pull requests and protected branches.
- Validate GitHub Actions, container build files, actual shell scripts, Python syntax, JSON/TOML, systemd units, and Just recipes.
- Install Actionlint, Hadolint, and Just from pinned, checksum-verified upstream releases.

## Why

The main branch ruleset needs a reliable required status check. The previous lint workflow only covered files ending in `.sh`, while much of KythOS is implemented in extensionless executable scripts.

## Validation

- Hosted `Validation` run passed on `testing` in 15 seconds.
- Local ShellCheck, Bash syntax, Python parsing, structured config, systemd, Just, Actionlint, and Hadolint checks passed.
