### PR TITLE
security: mature GitHub and publishing safeguards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner for everything
+* @mrtrick37
+
+# Workflow files require extra scrutiny — any change here affects the supply chain
+.github/workflows/ @mrtrick37

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What does this change?
+
+<!-- One or two sentences. What problem does it solve or what does it add? -->
+
+## How was it tested?
+
+<!-- How did you verify the change works? e.g. local build, booted ISO, checked a game, ran just lint -->
+
+## Checklist
+
+- [ ] `just lint` passes (shellcheck + shfmt)
+- [ ] Changes to build scripts tested with `just build` or `just build-live-iso`
+- [ ] New packages or COPRs justified in the PR description
+- [ ] Breaking changes to the installer or upgrade path noted above

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,13 +4,24 @@
     "config:best-practices",
   ],
 
-  "rebaseWhen": "never",
+  // Rebase only when there are actual conflicts; vulnerability PRs always rebase.
+  "rebaseWhen": "conflicted",
+
+  // Security update PRs: rebase immediately and automerge so they don't wait.
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "rebaseWhen": "behind-base-branch",
+    "automerge": true,
+    "labels": ["security"],
+  },
 
   "packageRules": [
     {
       "automerge": true,
       "matchUpdateTypes": ["pin", "pinDigest"]
     },
+    // Don't auto-update the base OS container digest inside workflow files —
+    // those are intentionally locked to specific Fedora 44 tags.
     {
       "enabled": false,
       "matchUpdateTypes": ["digest", "pinDigest", "pin"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,11 +7,12 @@
   // Rebase only when there are actual conflicts; vulnerability PRs always rebase.
   "rebaseWhen": "conflicted",
 
-  // Security update PRs: rebase immediately and automerge so they don't wait.
+  // Security updates remain visible for CI and maintainer review. KythOS is an
+  // OS image, so even urgent dependency changes can create boot regressions.
   "vulnerabilityAlerts": {
     "enabled": true,
     "rebaseWhen": "behind-base-branch",
-    "automerge": true,
+    "automerge": false,
     "labels": ["security"],
   },
 
@@ -19,6 +20,10 @@
     {
       "automerge": true,
       "matchUpdateTypes": ["pin", "pinDigest"]
+    },
+    {
+      "automerge": false,
+      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
     },
     // Don't auto-update the base OS container digest inside workflow files —
     // those are intentionally locked to specific Fedora 44 tags.

--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -120,6 +120,9 @@ jobs:
         run: mkdir -p output/live-iso
 
       - name: Build ISO with Titanoboa
+        # Third-party community action — no versioned releases exist; pinned to
+        # a specific commit SHA. Runs with elevated privileges (SYS_ADMIN,
+        # label=disable) inside the podman build above. Review before updating.
         uses: Zeglius/titanoboa@7737f4748458252ac827dca14b3d6dd09298472a
         with:
           image-ref: localhost/payload:latest

--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -1,13 +1,13 @@
 name: Build Live ISO
-run-name: "Build Live ISO — ${{ inputs.source_tag }}"
+run-name: "Build Live ISO - ${{ inputs.source_tag }}"
 
 on:
   workflow_dispatch:
     inputs:
       source_tag:
-        description: 'Source image tag to build ISO from'
+        description: Source image tag to build ISO from
         required: false
-        default: 'latest'
+        default: latest
         type: choice
         options:
           - latest
@@ -15,37 +15,42 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: build-live-iso-${{ inputs.source_tag }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build-iso:
-    name: Build ISO (${{ matrix.source_tag }})
+  build:
+    name: Build ISO (${{ inputs.source_tag }})
     runs-on: ubuntu-24.04
-    environment: ${{ matrix.source_tag == 'testing' && 'testing-release' || 'stable-release' }}
-    concurrency:
-      group: build-live-iso-${{ matrix.source_tag }}
-      cancel-in-progress: true
-    strategy:
-      fail-fast: false
-      matrix:
-        source_tag: ${{ fromJSON(format('["{0}"]', inputs.source_tag)) }}
+    timeout-minutes: 180
     permissions:
-      contents: write
+      contents: read
       packages: read
-      id-token: write
-      attestations: write
+    outputs:
+      artifact_name: ${{ steps.release.outputs.artifact_name }}
+      source_sha: ${{ steps.release.outputs.source_sha }}
+      release_id: ${{ steps.release.outputs.release_id }}
+      iso_basename: ${{ steps.release.outputs.iso_basename }}
+      channel_basename: ${{ steps.release.outputs.channel_basename }}
+      immutable_tag: ${{ steps.release.outputs.immutable_tag }}
+      source_image: ${{ steps.source_image.outputs.name }}
+      source_digest: ${{ steps.source_image.outputs.digest }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.source_tag == 'testing' && 'testing' || 'main' }}
+          ref: ${{ inputs.source_tag == 'testing' && 'testing' || 'main' }}
+          persist-credentials: false
 
       - name: Prepare immutable release identity
         id: release
         env:
-          SOURCE_TAG: ${{ matrix.source_tag }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
           SOURCE_SHA="$(git rev-parse HEAD)"
           SHORT_SHA="$(git rev-parse --short=8 HEAD)"
@@ -54,12 +59,14 @@ jobs:
           ISO_BASENAME="kyth-live-${SOURCE_TAG}-${RELEASE_ID}.iso"
           CHANNEL_BASENAME="kyth-live-${SOURCE_TAG}.iso"
           IMMUTABLE_TAG="iso-${SOURCE_TAG}-${RELEASE_ID}"
+          ARTIFACT_NAME="kyth-live-iso-${SOURCE_TAG}-${RELEASE_ID}"
 
           echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
           echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
           echo "iso_basename=${ISO_BASENAME}" >> "$GITHUB_OUTPUT"
           echo "channel_basename=${CHANNEL_BASENAME}" >> "$GITHUB_OUTPUT"
           echo "immutable_tag=${IMMUTABLE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -80,15 +87,10 @@ jobs:
           sudo mount -o compress-force=zstd:2 /mnt/podman-storage.img /var/lib/containers/storage
           sudo systemctl start podman.service
 
-      - name: Authenticate podman to GHCR
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | sudo podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-
       - name: Resolve source image digest
         id: source_image
         env:
-          SOURCE_TAG: ${{ matrix.source_tag }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
           IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}:${SOURCE_TAG}"
           DIGEST="$(sudo skopeo inspect --format '{{.Digest}}' "docker://${IMAGE}")"
@@ -99,18 +101,13 @@ jobs:
 
       - name: Build live payload container
         env:
-          SOURCE_TAG: ${{ matrix.source_tag }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
           SOURCE_IMAGE_PINNED: ${{ steps.source_image.outputs.pinned }}
         run: |
-          SOURCE_TAG="${{ matrix.source_tag }}"
-          BASE_IMAGE="${SOURCE_IMAGE_PINNED}"
-
-          # Titanoboa consumes this prepared live rootfs using the same
-          # container-native LiveCD contract as Bazzite.
           sudo podman build \
             --cap-add SYS_ADMIN \
             --security-opt label=disable \
-            --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+            --build-arg "BASE_IMAGE=${SOURCE_IMAGE_PINNED}" \
             --build-arg "SOURCE_TAG=${SOURCE_TAG}" \
             --tag localhost/payload:latest \
             -f installer/Containerfile \
@@ -120,26 +117,21 @@ jobs:
         run: mkdir -p output/live-iso
 
       - name: Build ISO with Titanoboa
-        # Third-party community action — no versioned releases exist; pinned to
-        # a specific commit SHA. Runs with elevated privileges (SYS_ADMIN,
-        # label=disable) inside the podman build above. Review before updating.
+        # This third-party action is pinned, but still runs only in the
+        # credential-free build job because it performs privileged operations.
         uses: Zeglius/titanoboa@7737f4748458252ac827dca14b3d6dd09298472a
         with:
           image-ref: localhost/payload:latest
-          iso-dest: ${{ runner.temp }}/kyth-live-${{ matrix.source_tag }}.iso
+          iso-dest: ${{ runner.temp }}/kyth-live-${{ inputs.source_tag }}.iso
 
-      - name: Move ISO into workspace
-        run: |
-          mv "${{ runner.temp }}/kyth-live-${{ matrix.source_tag }}.iso" \
-            "output/live-iso/${{ steps.release.outputs.iso_basename }}"
-
-      - name: Verify ISO artifact
+      - name: Move and verify ISO
         run: |
           ISO="output/live-iso/${{ steps.release.outputs.iso_basename }}"
+          mv "${{ runner.temp }}/kyth-live-${{ inputs.source_tag }}.iso" "${ISO}"
           test -s "${ISO}"
           echo "==> Built $(du -h "${ISO}" | cut -f1) ISO: ${ISO}"
 
-      - name: Generate ISO checksum
+      - name: Generate ISO checksums
         run: |
           ISO="output/live-iso/${{ steps.release.outputs.iso_basename }}"
           CHANNEL_CHECKSUM="output/live-iso/${{ steps.release.outputs.channel_basename }}-CHECKSUM"
@@ -148,14 +140,47 @@ jobs:
           printf '%s  %s\n' "${SHA256}" "${{ steps.release.outputs.channel_basename }}" \
             > "${CHANNEL_CHECKSUM}"
 
+      - name: Upload unsigned ISO artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.release.outputs.artifact_name }}
+          path: output/live-iso/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish ISO (${{ inputs.source_tag }})
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    environment: ${{ inputs.source_tag == 'testing' && 'testing-release' || 'stable-release' }}
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download built ISO
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: output/live-iso
+
+      - name: Verify transferred artifact
+        run: |
+          ISO="output/live-iso/${{ needs.build.outputs.iso_basename }}"
+          test -s "${ISO}"
+          (cd output/live-iso && sha256sum --check --strict "${{ needs.build.outputs.iso_basename }}-CHECKSUM")
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: 'v2.6.1'
+          cosign-release: v2.6.1
 
       - name: Sign ISO
         run: |
-          ISO="output/live-iso/${{ steps.release.outputs.iso_basename }}"
+          ISO="output/live-iso/${{ needs.build.outputs.iso_basename }}"
           cosign sign-blob -y "${ISO}" \
             --output-signature "${ISO}.sig" \
             --bundle "${ISO}.bundle"
@@ -164,25 +189,26 @@ jobs:
         id: attest_iso
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
-          subject-path: output/live-iso/${{ steps.release.outputs.iso_basename }}
+          subject-path: output/live-iso/${{ needs.build.outputs.iso_basename }}
 
-      - name: Generate ISO metadata
+      - name: Generate signed release metadata
         env:
-          SOURCE_TAG: ${{ matrix.source_tag }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
           ATTESTATION_URL: ${{ steps.attest_iso.outputs.attestation-url }}
-          ISO_BASENAME: ${{ steps.release.outputs.iso_basename }}
-          CHANNEL_BASENAME: ${{ steps.release.outputs.channel_basename }}
-          IMMUTABLE_TAG: ${{ steps.release.outputs.immutable_tag }}
-          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
-          SOURCE_IMAGE: ${{ steps.source_image.outputs.name }}
-          SOURCE_DIGEST: ${{ steps.source_image.outputs.digest }}
+          ISO_BASENAME: ${{ needs.build.outputs.iso_basename }}
+          CHANNEL_BASENAME: ${{ needs.build.outputs.channel_basename }}
+          IMMUTABLE_TAG: ${{ needs.build.outputs.immutable_tag }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          SOURCE_IMAGE: ${{ needs.build.outputs.source_image }}
+          SOURCE_DIGEST: ${{ needs.build.outputs.source_digest }}
         run: |
           ISO="output/live-iso/${ISO_BASENAME}"
           SHA256="$(sha256sum "${ISO}" | awk '{print $1}')"
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export SHA256 BUILD_DATE
           python3 - <<'PY'
-          import json, os
+          import json
+          import os
           from pathlib import Path
 
           tag = os.environ["SOURCE_TAG"]
@@ -195,7 +221,7 @@ jobs:
               "signature": iso.name + ".sig",
               "bundle": iso.name + ".bundle",
               "checksum": iso.name + "-CHECKSUM",
-              "attestation_url": os.environ.get("ATTESTATION_URL", ""),
+              "attestation_url": os.environ["ATTESTATION_URL"],
               "source_image": os.environ["SOURCE_IMAGE"],
               "source_image_digest": os.environ["SOURCE_DIGEST"],
               "pinned_source_image": os.environ["SOURCE_IMAGE"] + "@" + os.environ["SOURCE_DIGEST"],
@@ -204,7 +230,7 @@ jobs:
               "build_date": os.environ["BUILD_DATE"],
               "release_tag": os.environ["IMMUTABLE_TAG"],
               "download_url": f"{base_url}/{iso.name}",
-              "workflow_run": f"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "workflow_run": f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
           }
           Path(str(iso) + ".json").write_text(json.dumps(metadata, indent=2) + "\n")
 
@@ -225,23 +251,15 @@ jobs:
           cp "${ISO}.sig" "output/live-iso/${CHANNEL_BASENAME}.sig"
           cp "${ISO}.bundle" "output/live-iso/${CHANNEL_BASENAME}.bundle"
 
-      - name: Upload ISO artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: kyth-live-iso-${{ matrix.source_tag }}-${{ steps.release.outputs.release_id }}
-          path: output/live-iso/*
-          if-no-files-found: error
-
       - name: Upload ISO to Cloudflare R2
         env:
-          AWS_ACCESS_KEY_ID:     ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ACCOUNT_ID:         ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
         run: |
-          ISO="output/live-iso/${{ steps.release.outputs.iso_basename }}"
-          CHANNEL="output/live-iso/${{ steps.release.outputs.channel_basename }}"
+          ISO="output/live-iso/${{ needs.build.outputs.iso_basename }}"
+          CHANNEL="output/live-iso/${{ needs.build.outputs.channel_basename }}"
 
-          # Immutable objects are never overwritten and remain independently verifiable.
           for artifact in "${ISO}" "${ISO}-CHECKSUM" "${ISO}.sig" "${ISO}.bundle" "${ISO}.json"; do
             aws s3 cp "${artifact}" \
               "s3://kyth-releases/$(basename "${artifact}")" \
@@ -249,7 +267,6 @@ jobs:
               --no-progress
           done
 
-          # Stable channel aliases preserve existing download URLs.
           aws s3 cp "${ISO}" "s3://kyth-releases/$(basename "${CHANNEL}")" \
             --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress
           for suffix in -CHECKSUM .sig .bundle .json; do
@@ -259,43 +276,48 @@ jobs:
               --no-progress
           done
 
-      - name: Publish release notes to GitHub Releases
+      - name: Publish GitHub releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_TAG: ${{ inputs.source_tag }}
+          CHANNEL_TAG: ${{ inputs.source_tag == 'testing' && 'iso-testing' || 'iso-latest' }}
+          IMMUTABLE_TAG: ${{ needs.build.outputs.immutable_tag }}
+          RELEASE_ID: ${{ needs.build.outputs.release_id }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          SOURCE_DIGEST: ${{ needs.build.outputs.source_digest }}
+          ATTESTATION_URL: ${{ steps.attest_iso.outputs.attestation-url }}
+          ISO_BASENAME: ${{ needs.build.outputs.iso_basename }}
+          CHANNEL_BASENAME: ${{ needs.build.outputs.channel_basename }}
         run: |
-          SOURCE_TAG="${{ matrix.source_tag }}"
-          CHANNEL_TAG="${{ matrix.source_tag == 'testing' && 'iso-testing' || 'iso-latest' }}"
-          IMMUTABLE_TAG="${{ steps.release.outputs.immutable_tag }}"
-          SOURCE_SHA="${{ steps.release.outputs.source_sha }}"
-          SOURCE_DIGEST="${{ steps.source_image.outputs.digest }}"
-          ISO="output/live-iso/${{ steps.release.outputs.iso_basename }}"
-          CHANNEL="output/live-iso/${{ steps.release.outputs.channel_basename }}"
+          ISO="output/live-iso/${ISO_BASENAME}"
+          CHANNEL="output/live-iso/${CHANNEL_BASENAME}"
           PUBLIC_BASE="https://pub-9a3cc72972ea44c4ae7504ee7cda1fa6.r2.dev"
-          IMMUTABLE_ISO_URL="${PUBLIC_BASE}/$(basename "${ISO}")"
-          CHANNEL_ISO_URL="${PUBLIC_BASE}/$(basename "${CHANNEL}")"
+          IMMUTABLE_ISO_URL="${PUBLIC_BASE}/${ISO_BASENAME}"
+          CHANNEL_ISO_URL="${PUBLIC_BASE}/${CHANNEL_BASENAME}"
           IMMUTABLE_RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${IMMUTABLE_TAG}"
 
-          if [ "${SOURCE_TAG}" = "testing" ]; then
-            CHANNEL_TITLE="Kyth Live ISO — Testing"
-            IMMUTABLE_TITLE="Kyth Live ISO — Testing — ${{ steps.release.outputs.release_id }}"
+          if [[ "${SOURCE_TAG}" == "testing" ]]; then
+            CHANNEL_TITLE="Kyth Live ISO - Testing"
+            IMMUTABLE_TITLE="Kyth Live ISO - Testing - ${RELEASE_ID}"
             PRERELEASE="--prerelease"
             LATEST=""
           else
-            CHANNEL_TITLE="Kyth Live ISO — Stable"
-            IMMUTABLE_TITLE="Kyth Live ISO — Stable — ${{ steps.release.outputs.release_id }}"
+            CHANNEL_TITLE="Kyth Live ISO - Stable"
+            IMMUTABLE_TITLE="Kyth Live ISO - Stable - ${RELEASE_ID}"
             PRERELEASE=""
             LATEST="--latest"
           fi
 
           IMMUTABLE_NOTES="$(mktemp)"
           cat > "${IMMUTABLE_NOTES}" <<EOF
-          Permanent KythOS ISO build from \`${SOURCE_TAG}\`.
+          Permanent KythOS ISO build from **${SOURCE_TAG}**.
 
           **[Download immutable ISO](${IMMUTABLE_ISO_URL})** | [Checksum](${IMMUTABLE_ISO_URL}-CHECKSUM)
 
-          - Source commit: \`${SOURCE_SHA}\`
-          - Source image digest: \`${SOURCE_DIGEST}\`
+          - Source commit: **${SOURCE_SHA}**
+          - Source image digest: **${SOURCE_DIGEST}**
           - Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Build provenance: ${ATTESTATION_URL}
 
           The checksum, Cosign signature and bundle, metadata, and GitHub build provenance are attached to this release.
           EOF
@@ -310,14 +332,15 @@ jobs:
 
           CHANNEL_NOTES="$(mktemp)"
           cat > "${CHANNEL_NOTES}" <<EOF
-          This is the moving \`${SOURCE_TAG}\` channel pointer.
+          This is the moving **${SOURCE_TAG}** channel pointer.
 
           **[Download current ISO](${CHANNEL_ISO_URL})** | [Checksum](${CHANNEL_ISO_URL}-CHECKSUM)
 
-          Current immutable release: [\`${IMMUTABLE_TAG}\`](${IMMUTABLE_RELEASE_URL})
+          Current immutable release: [${IMMUTABLE_TAG}](${IMMUTABLE_RELEASE_URL})
 
-          - Source commit: \`${SOURCE_SHA}\`
-          - Source image digest: \`${SOURCE_DIGEST}\`
+          - Source commit: **${SOURCE_SHA}**
+          - Source image digest: **${SOURCE_DIGEST}**
+          - Build provenance: ${ATTESTATION_URL}
           EOF
 
           if gh release view "${CHANNEL_TAG}" >/dev/null 2>&1; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
 
       - name: Capture checked-out commit
         id: checkout_sha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,12 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "${{ github.event.repository.name }}"  # output image name, usually same as repo name
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build_push:
     name: Build and push (${{ matrix.branch }}, ${{ matrix.kernel_flavor }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     # fail-fast is false below, so a cachy failure never blocks the fedora leg
     # or the live ISO dispatch. Let it mark the run red — continue-on-error here
     # would hide scheduled cachy build breakage indefinitely.
@@ -194,6 +196,11 @@ jobs:
             TAG_ARGS+=(--tag "${IMAGE_FULL}:${tag}")
           done
 
+          LABEL_ARGS=()
+          while IFS= read -r label; do
+            [[ -n "${label}" ]] && LABEL_ARGS+=(--label "${label}")
+          done <<< "${{ steps.metadata.outputs.labels }}"
+
           # MOK_KEY is optional — builds without it, or with a stale key, skip
           # vmlinuz signing gracefully for the regular container image.
           # To enable Secure Boot: add MOK_KEY as a repository secret containing
@@ -218,6 +225,7 @@ jobs:
             --cache-from "type=registry,ref=${FINAL_CACHE_REF}" \
             --cache-to "type=registry,ref=${FINAL_CACHE_REF},mode=max" \
             "${TAG_ARGS[@]}" \
+            "${LABEL_ARGS[@]}" \
             --output "type=image,push=true,compression=zstd,force-compression=true,oci-mediatypes=true" \
             .
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: CodeQL
+
+on:
+  push:
+    branches: [main, testing]
+    paths:
+      - '**/*.py'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [main, testing]
+    paths:
+      - '**/*.py'
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly Monday — catches new CVEs against unchanged code
+
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: /language:python

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install ORAS
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           # Full history so the push/PR base commit exists locally — with the
           # default shallow clone, git diff fails with "bad object" and the
           # changed-file detection silently skips every shellcheck run.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: read-all
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -5,13 +5,11 @@ on:
   workflow_run:
     workflows: ["Build container image"]
     types: [completed]
-    # testing included so push-built :testing images are signed/SBOM'd
-    # immediately instead of waiting for the next scheduled main build.
     branches: [main, testing]
   workflow_dispatch:
     inputs:
       source_tag:
-        description: 'Image tag to process'
+        description: Image tag to process
         required: false
         default: all
         type: choice
@@ -26,31 +24,29 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  metadata:
-    name: Metadata (${{ matrix.source_tag }})
+  prepare:
+    name: Prepare metadata (${{ matrix.source_tag }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    concurrency:
-      group: supply-chain-${{ matrix.source_tag }}
-      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
         source_tag: ${{ github.event_name == 'workflow_dispatch' && (inputs.source_tag == 'all' && fromJSON('["latest","testing"]') || fromJSON(format('["{0}"]', inputs.source_tag))) || (github.event.workflow_run.event == 'schedule' && fromJSON('["latest","testing"]') || fromJSON(format('["{0}"]', github.event.workflow_run.head_branch == 'testing' && 'testing' || 'latest'))) }}
     permissions:
-      contents: write
-      packages: write
-      id-token: write
-      attestations: write
+      contents: read
+      packages: read
+    concurrency:
+      group: supply-chain-prepare-${{ matrix.source_tag }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.source_tag == 'testing' && 'testing' || 'main' }}
+          persist-credentials: false
 
-      # The RPM manifest step docker-pulls the full image (~5 GB compressed).
-      # Free space so the runner doesn't run out mid-pull.
       - name: Maximize build space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -63,21 +59,15 @@ jobs:
 
       - name: Prepare metadata variables
         id: meta
+        env:
+          SOURCE_TAG: ${{ matrix.source_tag }}
         run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}"
-          TAG="${{ matrix.source_tag }}"
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
           DATE_SHORT="$(date -u +%Y%m%d)"
-          echo "image=${IMAGE,,}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tag=${SOURCE_TAG}" >> "$GITHUB_OUTPUT"
           echo "date_short=${DATE_SHORT}" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -85,32 +75,20 @@ jobs:
       - name: Install ORAS
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
 
-      - name: Enable containerd snapshotter
-        run: |
-          sudo systemctl stop docker docker.socket 2>/dev/null || true
-          echo '{"features":{"containerd-snapshotter":true}}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl start docker
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-
       - name: Resolve current and previous image digests
         id: image
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          DATE_SHORT: ${{ steps.meta.outputs.date_short }}
         run: |
-          IMAGE="${{ steps.meta.outputs.image }}"
-          TAG="${{ steps.meta.outputs.tag }}"
           CURRENT_DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ .Manifest.Digest }}')"
           CURRENT_VERSION="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ index .Image.Config.Labels "org.opencontainers.image.version" }}' 2>/dev/null || true)"
 
-          # Fall back if the label is absent, literally "<no value>", or if it
-          # resolved to a base-image value (e.g. "44" from Fedora Kinoite) rather
-          # than our expected format of "${TAG}.YYYYMMDD".
           if [[ -z "${CURRENT_VERSION}" || "${CURRENT_VERSION}" == "<no value>" || \
                 ! "${CURRENT_VERSION}" =~ ^${TAG}\. ]]; then
-            CURRENT_VERSION="${TAG}.${{ steps.meta.outputs.date_short }}"
+            CURRENT_VERSION="${TAG}.${DATE_SHORT}"
           fi
-
-          echo "current_digest=${CURRENT_DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "current_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
 
           TAG_PREFIX="${CURRENT_VERSION%.*}"
           PREVIOUS_TAG="$(oras repo tags "${IMAGE}" \
@@ -118,34 +96,27 @@ jobs:
             | grep -vx "${CURRENT_VERSION}" \
             | sort \
             | tail -n1 || true)"
-
+          PREVIOUS_DIGEST=""
           if [[ -n "${PREVIOUS_TAG}" ]]; then
             PREVIOUS_DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${PREVIOUS_TAG}" --format '{{ .Manifest.Digest }}' 2>/dev/null || true)"
-            echo "previous_tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
-            echo "previous_digest=${PREVIOUS_DIGEST}" >> "$GITHUB_OUTPUT"
-          else
-            echo "previous_tag=" >> "$GITHUB_OUTPUT"
-            echo "previous_digest=" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "Current: ${IMAGE}:${TAG} ${CURRENT_DIGEST} (${CURRENT_VERSION})"
-          echo "Previous: ${PREVIOUS_TAG:-none}"
+          echo "current_digest=${CURRENT_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "current_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "previous_digest=${PREVIOUS_DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Capture RPM manifest
+        id: rpm_manifest
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.image.outputs.current_version }}
         run: |
-          IMAGE="${{ steps.meta.outputs.image }}"
-          TAG="${{ steps.meta.outputs.tag }}"
-          OUT_FILE="rpm-manifest-${TAG}-${{ steps.image.outputs.current_version }}.txt"
+          OUT_FILE="rpm-manifest-${TAG}-${VERSION}.txt"
           docker run --rm "${IMAGE}:${TAG}" \
             bash -lc "rpm -qa --qf '%{name}-%{version}-%{release}.%{arch}\\n' | sort" \
             > "${OUT_FILE}"
-          echo "RPM_MANIFEST=${OUT_FILE}" >> "$GITHUB_ENV"
-
-      - name: Upload RPM manifest artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: rpm-manifest-${{ matrix.source_tag }}-${{ github.run_id }}
-          path: ${{ env.RPM_MANIFEST }}
+          echo "path=${OUT_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Syft
         id: setup_syft
@@ -159,110 +130,225 @@ jobs:
           echo "${SYFT_SHA256}  ${RUNNER_TEMP}/${ARCHIVE}" | sha256sum --check
           tar --extract --gzip --file "${RUNNER_TEMP}/${ARCHIVE}" --directory "${RUNNER_TEMP}" syft
           chmod +x "${RUNNER_TEMP}/syft"
-          echo "cmd=${RUNNER_TEMP}/syft" >> "${GITHUB_OUTPUT}"
+          echo "cmd=${RUNNER_TEMP}/syft" >> "$GITHUB_OUTPUT"
 
       - name: Generate image SBOM
-        id: generate_sbom
+        id: sbom
         timeout-minutes: 30
         env:
           SYFT_CMD: ${{ steps.setup_syft.outputs.cmd }}
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.image.outputs.current_version }}
+          DIGEST: ${{ steps.image.outputs.current_digest }}
         run: |
-          IMAGE="${{ steps.meta.outputs.image }}"
-          TAG="${{ steps.meta.outputs.tag }}"
-          SBOM="kyth-${TAG}-${{ steps.image.outputs.current_version }}.syft.json"
-          # Use registry: source so Syft streams layers from GHCR directly
-          # instead of docker-saving the full image — avoids OOM on a ~10 GB OS image.
-          # Credentials are read from ~/.docker/config.json set by the earlier docker login.
+          SBOM="kyth-${TAG}-${VERSION}.syft.json"
           "${SYFT_CMD}" "registry:${IMAGE}:${TAG}" \
-            --source-name "${IMAGE}@${{ steps.image.outputs.current_digest }}" \
+            --source-name "${IMAGE}@${DIGEST}" \
             -o "syft-json=${SBOM}"
           echo "path=${SBOM}" >> "$GITHUB_OUTPUT"
-          du -h "${SBOM}"
 
-      - name: Upload SBOM workflow artifact
+      - name: Generate SBOM-powered changelog
+        id: changelog
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          CURRENT_TAG: ${{ steps.image.outputs.current_version }}
+          CURRENT_DIGEST: ${{ steps.image.outputs.current_digest }}
+          PREVIOUS_DIGEST: ${{ steps.image.outputs.previous_digest }}
+          CURRENT_SHA: ${{ steps.meta.outputs.sha }}
+          SOURCE_TAG: ${{ matrix.source_tag }}
+        run: |
+          NOTES="image-changelog-${CURRENT_TAG}.md"
+          BRANCH=main
+          if [[ "${SOURCE_TAG}" == "testing" ]]; then
+            BRANCH=testing
+          fi
+          python3 .github/scripts/kyth_changelog.py \
+            --image "${IMAGE}" \
+            --branch "${BRANCH}" \
+            --current-tag "${CURRENT_TAG}" \
+            --current-digest "${CURRENT_DIGEST}" \
+            --previous-digest "${PREVIOUS_DIGEST}" \
+            --current-sha "${CURRENT_SHA}" \
+            --output "${NOTES}"
+          echo "path=${NOTES}" >> "$GITHUB_OUTPUT"
+
+      - name: Package publish inputs
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          SOURCE_SHA: ${{ steps.meta.outputs.sha }}
+          CURRENT_DIGEST: ${{ steps.image.outputs.current_digest }}
+          CURRENT_VERSION: ${{ steps.image.outputs.current_version }}
+          PREVIOUS_DIGEST: ${{ steps.image.outputs.previous_digest }}
+          RPM_MANIFEST: ${{ steps.rpm_manifest.outputs.path }}
+          SBOM: ${{ steps.sbom.outputs.path }}
+          NOTES: ${{ steps.changelog.outputs.path }}
+        run: |
+          mkdir -p output/supply-chain
+          cp "${RPM_MANIFEST}" "${SBOM}" "${NOTES}" output/supply-chain/
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          metadata = {
+              "image": os.environ["IMAGE"],
+              "tag": os.environ["TAG"],
+              "source_sha": os.environ["SOURCE_SHA"],
+              "current_digest": os.environ["CURRENT_DIGEST"],
+              "current_version": os.environ["CURRENT_VERSION"],
+              "previous_digest": os.environ["PREVIOUS_DIGEST"],
+              "rpm_manifest": Path(os.environ["RPM_MANIFEST"]).name,
+              "sbom": Path(os.environ["SBOM"]).name,
+              "notes": Path(os.environ["NOTES"]).name,
+          }
+          Path("output/supply-chain/metadata.json").write_text(
+              json.dumps(metadata, indent=2) + "\n"
+          )
+          PY
+
+      - name: Upload prepared metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: image-sbom-${{ matrix.source_tag }}-${{ github.run_id }}
-          path: ${{ steps.generate_sbom.outputs.path }}
+          name: supply-chain-input-${{ matrix.source_tag }}-${{ github.run_id }}
+          path: output/supply-chain/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish metadata (${{ matrix.source_tag }})
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: ${{ matrix.source_tag == 'testing' && 'testing-release' || 'stable-release' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        source_tag: ${{ github.event_name == 'workflow_dispatch' && (inputs.source_tag == 'all' && fromJSON('["latest","testing"]') || fromJSON(format('["{0}"]', inputs.source_tag))) || (github.event.workflow_run.event == 'schedule' && fromJSON('["latest","testing"]') || fromJSON(format('["{0}"]', github.event.workflow_run.head_branch == 'testing' && 'testing' || 'latest'))) }}
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+    concurrency:
+      group: supply-chain-publish-${{ matrix.source_tag }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Download prepared metadata
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: supply-chain-input-${{ matrix.source_tag }}-${{ github.run_id }}
+          path: output/supply-chain
+
+      - name: Validate publish inputs
+        id: meta
+        run: |
+          METADATA=output/supply-chain/metadata.json
+          jq -e . "${METADATA}" >/dev/null
+          IMAGE="$(jq -r .image "${METADATA}")"
+          TAG="$(jq -r .tag "${METADATA}")"
+          SOURCE_SHA="$(jq -r .source_sha "${METADATA}")"
+          DIGEST="$(jq -r .current_digest "${METADATA}")"
+          VERSION="$(jq -r .current_version "${METADATA}")"
+          SBOM="$(jq -r .sbom "${METADATA}")"
+          NOTES="$(jq -r .notes "${METADATA}")"
+
+          [[ "${IMAGE}" =~ ^ghcr\.io/[a-z0-9._/-]+$ ]]
+          [[ "${TAG}" == "latest" || "${TAG}" == "testing" ]]
+          [[ "${TAG}" == "${{ matrix.source_tag }}" ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${VERSION}" =~ ^[a-z0-9._-]+$ ]]
+          [[ "${SBOM}" == "$(basename "${SBOM}")" && -s "output/supply-chain/${SBOM}" ]]
+          [[ "${NOTES}" == "$(basename "${NOTES}")" && -s "output/supply-chain/${NOTES}" ]]
+
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sbom=${SBOM}" >> "$GITHUB_OUTPUT"
+          echo "notes=${NOTES}" >> "$GITHUB_OUTPUT"
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: 'v2.6.1'
+          cosign-release: v2.6.1
+
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GH_TOKEN}" | oras login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Sign container image
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          IMAGE="${{ steps.meta.outputs.image }}"
-          TAG="${{ steps.meta.outputs.tag }}"
-          CURRENT_VERSION="${{ steps.image.outputs.current_version }}"
-
-          cosign sign -y "${IMAGE}@${{ steps.image.outputs.current_digest }}"
+          cosign sign -y "${IMAGE}@${DIGEST}"
           cosign sign -y "${IMAGE}:${TAG}"
-          cosign sign -y "${IMAGE}:${CURRENT_VERSION}"
-
-          if [[ "${TAG}" == "latest" && "${CURRENT_VERSION}" =~ ^latest\.([0-9]{8})$ ]]; then
+          cosign sign -y "${IMAGE}:${VERSION}"
+          if [[ "${TAG}" == "latest" && "${VERSION}" =~ ^latest\.([0-9]{8})$ ]]; then
             cosign sign -y "${IMAGE}:${BASH_REMATCH[1]}"
           fi
 
-      - name: Attach SBOM to image
+      - name: Attach and sign SBOM
         id: attach_sbom
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SBOM: output/supply-chain/${{ steps.meta.outputs.sbom }}
         run: |
-          IMAGE="${{ steps.meta.outputs.image }}"
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-          SBOM="${{ steps.generate_sbom.outputs.path }}"
           oras attach \
             --artifact-type application/vnd.syft+json \
             --annotation "org.opencontainers.image.title=$(basename "${SBOM}")" \
-            --annotation "org.opencontainers.image.description=Syft SBOM for Kyth image ${{ steps.image.outputs.current_version }}" \
-            "${IMAGE}@${{ steps.image.outputs.current_digest }}" \
+            --annotation "org.opencontainers.image.description=Syft SBOM for Kyth image ${VERSION}" \
+            "${IMAGE}@${DIGEST}" \
             "${SBOM}"
-          SBOM_DIGEST="$(oras discover --format json "${IMAGE}@${{ steps.image.outputs.current_digest }}" \
+          SBOM_DIGEST="$(oras discover --format json "${IMAGE}@${DIGEST}" \
             | jq -r '.referrers[] | select(.artifactType == "application/vnd.syft+json") | .digest' \
             | tail -n1)"
-          test -n "${SBOM_DIGEST}"
+          [[ "${SBOM_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
           echo "digest=${SBOM_DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Sign SBOM OCI artifact
-        run: |
-          IMAGE="${{ steps.meta.outputs.image }}"
-          cosign sign -y "${IMAGE}@${{ steps.attach_sbom.outputs.digest }}"
+          cosign sign -y "${IMAGE}@${SBOM_DIGEST}"
 
       - name: Attest image build provenance
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ steps.meta.outputs.image }}
-          subject-digest: ${{ steps.image.outputs.current_digest }}
+          subject-digest: ${{ steps.meta.outputs.digest }}
           push-to-registry: true
-
-      - name: Generate SBOM-powered changelog
-        id: image_changelog
-        run: |
-          NOTES="image-changelog-${{ steps.image.outputs.current_version }}.md"
-          python3 .github/scripts/kyth_changelog.py \
-            --image "${{ steps.meta.outputs.image }}" \
-            --branch "${{ matrix.source_tag == 'testing' && 'testing' || 'main' }}" \
-            --current-tag "${{ steps.image.outputs.current_version }}" \
-            --current-digest "${{ steps.image.outputs.current_digest }}" \
-            --previous-digest "${{ steps.image.outputs.previous_digest }}" \
-            --current-sha "${{ steps.meta.outputs.sha }}" \
-            --output "${NOTES}"
-          echo "path=${NOTES}" >> "$GITHUB_OUTPUT"
 
       - name: Publish image changelog release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SOURCE_SHA: ${{ steps.meta.outputs.source_sha }}
+          NOTES: output/supply-chain/${{ steps.meta.outputs.notes }}
+          SOURCE_TAG: ${{ matrix.source_tag }}
         run: |
-          VERSION="${{ steps.image.outputs.current_version }}"
-          TAG="image-${VERSION//./-}"
-          TITLE="Kyth Image — ${VERSION}"
-          NOTES="${{ steps.image_changelog.outputs.path }}"
+          RELEASE_TAG="image-${VERSION//./-}"
+          TITLE="Kyth Image - ${VERSION}"
           PRERELEASE=""
-          if [[ "${{ matrix.source_tag }}" != "latest" ]]; then
+          if [[ "${SOURCE_TAG}" != "latest" ]]; then
             PRERELEASE="--prerelease"
           fi
 
-          if gh release view "${TAG}" &>/dev/null; then
-            gh release edit "${TAG}" --title "${TITLE}" --notes-file "${NOTES}" ${PRERELEASE}
+          if gh release view "${RELEASE_TAG}" &>/dev/null; then
+            gh release edit "${RELEASE_TAG}" --title "${TITLE}" --notes-file "${NOTES}" ${PRERELEASE}
           else
-            gh release create "${TAG}" --title "${TITLE}" --notes-file "${NOTES}" ${PRERELEASE}
+            gh release create "${RELEASE_TAG}" \
+              --target "${SOURCE_SHA}" \
+              --title "${TITLE}" \
+              --notes-file "${NOTES}" \
+              ${PRERELEASE}
           fi

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -101,7 +101,11 @@ jobs:
           CURRENT_DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ .Manifest.Digest }}')"
           CURRENT_VERSION="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ index .Image.Config.Labels "org.opencontainers.image.version" }}' 2>/dev/null || true)"
 
-          if [[ -z "${CURRENT_VERSION}" || "${CURRENT_VERSION}" == "<no value>" ]]; then
+          # Fall back if the label is absent, literally "<no value>", or if it
+          # resolved to a base-image value (e.g. "44" from Fedora Kinoite) rather
+          # than our expected format of "${TAG}.YYYYMMDD".
+          if [[ -z "${CURRENT_VERSION}" || "${CURRENT_VERSION}" == "<no value>" || \
+                ! "${CURRENT_VERSION}" =~ ^${TAG}\. ]]; then
             CURRENT_VERSION="${TAG}.${{ steps.meta.outputs.date_short }}"
           fi
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -49,9 +49,8 @@ jobs:
         with:
           ref: ${{ matrix.source_tag == 'testing' && 'testing' || 'main' }}
 
-      # The SBOM step needs ~2x the uncompressed image size on disk: one copy
-      # in the Docker store plus the docker-save tarball syft exports before
-      # scanning. Stock runners don't have that much free space.
+      # The RPM manifest step docker-pulls the full image (~5 GB compressed).
+      # Free space so the runner doesn't run out mid-pull.
       - name: Maximize build space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -160,14 +159,17 @@ jobs:
 
       - name: Generate image SBOM
         id: generate_sbom
+        timeout-minutes: 30
         env:
           SYFT_CMD: ${{ steps.setup_syft.outputs.cmd }}
         run: |
           IMAGE="${{ steps.meta.outputs.image }}"
           TAG="${{ steps.meta.outputs.tag }}"
           SBOM="kyth-${TAG}-${{ steps.image.outputs.current_version }}.syft.json"
-          docker image inspect "${IMAGE}:${TAG}" >/dev/null
-          "${SYFT_CMD}" "docker:${IMAGE}:${TAG}" \
+          # Use registry: source so Syft streams layers from GHCR directly
+          # instead of docker-saving the full image — avoids OOM on a ~10 GB OS image.
+          # Credentials are read from ~/.docker/config.json set by the earlier docker login.
+          "${SYFT_CMD}" "registry:${IMAGE}:${TAG}" \
             --source-name "${IMAGE}@${{ steps.image.outputs.current_digest }}" \
             -o "syft-json=${SBOM}"
           echo "path=${SBOM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ACTIONLINT_VERSION: 1.7.7
   HADOLINT_VERSION: 2.14.0
   JUST_VERSION: 1.52.0

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pinned validators
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to KythOS
+
+Thanks for your interest. KythOS is a personal daily-driver OS — contributions
+are welcome but the bar is practical: changes need to work on real hardware and
+not break the live ISO boot path.
+
+## Branches
+
+| Branch | Purpose |
+|---|---|
+| `main` | Stable channel — maps to `:latest` image and `iso-latest` |
+| `testing` | Development — maps to `:testing` image and `iso-testing` |
+
+Open PRs against `testing`. After validation on real hardware, tested changes
+merge to `main`.
+
+## Local Build
+
+You need Docker (or Podman) and [just](https://github.com/casey/just).
+
+```bash
+# Build both the base layer and the final OS image
+just build
+
+# Build and boot the live ISO in QEMU (requires SPICE client)
+just rebuild-live-iso
+just run-live-iso-native
+
+# Lint and format shell scripts before pushing
+just lint
+just format
+```
+
+Feature flags let you skip optional build steps:
+
+```bash
+ENABLE_ANANICY=0 ENABLE_SCX=0 just build
+```
+
+## What Makes a Good PR
+
+- **Packages**: justify why it belongs in a base OS image, not a Flatpak
+- **COPRs**: link to the COPR, explain the update cadence, note if it's a
+  known-stable maintainer (e.g. `xxmitsu/mesa-git`)
+- **Scripts in `build_files/scripts/`**: must pass `shellcheck --severity=error`
+  and `shfmt -d` (run `just lint && just format` locally)
+- **Python**: must pass `python3 -c "import ast; ast.parse(open('file.py').read())"`
+  — syntax only, but CodeQL runs on every PR for security issues
+- **Dockerfiles**: must pass `hadolint --failure-threshold error`
+- **Breaking changes to the installer or upgrade path**: describe the impact in
+  the PR body; include a note if users need to reinstall vs. `bootc upgrade`
+
+## CI Checks
+
+All PRs run:
+
+- **Validation** — actionlint, hadolint, shellcheck, Python AST, TOML/JSON,
+  systemd unit verify, Justfile parse
+- **Lint** — shellcheck on changed `.sh` files
+- **CodeQL** — static analysis of Python code
+
+The build and supply-chain workflows run on merge to `main`/`testing`, not on PRs,
+to avoid burning CI minutes on draft work.
+
+## Reporting Bugs
+
+Use the issue templates — they ask for the right information up front. For
+security issues, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [Gaming Docs](docs/gaming-validation-matrix.md) |
 [Report A Bug](https://github.com/mrtrick37/kyth/issues)
 
+[![Build](https://github.com/mrtrick37/kyth/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/mrtrick37/kyth/actions/workflows/build.yml)
+[![CVE Scan](https://github.com/mrtrick37/kyth/actions/workflows/cve-scan.yml/badge.svg)](https://github.com/mrtrick37/kyth/actions/workflows/cve-scan.yml)
+[![Scorecard](https://api.securityscorecardcards.dev/projects/github.com/mrtrick37/kyth/badge)](https://securityscorecards.dev/viewer/?uri=github.com/mrtrick37/kyth)
+
 <img src="build_files/wallpaper/kyth-wallpaper.svg" alt="KythOS wallpaper" width="100%">
 
 </div>


### PR DESCRIPTION
## Summary

- publish `CODEOWNERS`, a pull request template, contribution guidance, and Python CodeQL scanning on `main`
- add workflow timeouts, OCI label propagation, pinned checkout credential handling, and safer Renovate behavior
- split live ISO construction from signing, attestation, R2 upload, and GitHub release publication
- split SBOM/RPM/changelog generation from image signing, OCI attachment, attestation, and release publication
- keep required-review counts compatible with a solo maintainer while preserving PR, CI, signature, and environment controls

## Security model

Privileged publish jobs no longer check out the repository or execute project-owned scripts. The Titanoboa ISO builder runs with a read-only token and no release environment, OIDC permission, cloud credentials, or repository write permission. Container metadata preparation follows the same read-only pattern. Prepared artifacts and metadata are validated again before privileged publication.

Renovate security updates remain visible for CI and maintainer review instead of auto-merging into an operating-system image. Workflow dependency updates are never auto-merged.

## Validation

- checksum-verified `actionlint` 1.7.7 with the repository CI arguments
- parsed every `.github/**/*.yml` file with PyYAML
- compiled installer and changelog Python sources
- verified every external Action reference uses a full 40-character commit SHA
- `git diff --check`

`just check` also parsed the Justfiles, but reports pre-existing formatting differences in `build_files/just/kyth.just`; this PR does not modify that file.