### PR TITLE
ci: remove global env from scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,9 +11,6 @@ on:
 
 permissions: read-all
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   analysis:
     name: Scorecard analysis


### PR DESCRIPTION
## Summary

- Removes the top-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` block from `scorecard.yml`
- OSSF Scorecard's API rejects workflow files with global `env:` or `defaults:` blocks (HTTP 400), preventing results from uploading
- The flag has no effect here — Scorecard runs in its own container image, not through the Node.js action runner
- This fix already exists on `testing` (commit `55da696`) and was missed when PR #136 was squash-merged

## Test plan

- [ ] Scorecard workflow runs on next push to `main` or weekly schedule without HTTP 400 error
- [ ] Results appear in Security → Code scanning on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)