### PR TITLE
Remove FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env variable

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,9 +11,6 @@ on:
 
 permissions: read-all
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   analysis:
     name: Scorecard analysis


### PR DESCRIPTION
Removed environment variable for Node.js version.

## What does this change?

<!-- One or two sentences. What problem does it solve or what does it add? -->

## How was it tested?

<!-- How did you verify the change works? e.g. local build, booted ISO, checked a game, ran just lint -->

## Checklist

- [ ] `just lint` passes (shellcheck + shfmt)
- [ ] Changes to build scripts tested with `just build` or `just build-live-iso`
- [ ] New packages or COPRs justified in the PR description
- [ ] Breaking changes to the installer or upgrade path noted above
