### PR TITLE
ci: delete and recreate channel releases to reset publication timestamp

### DIFF
--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -690,16 +690,12 @@ jobs:
           } > "${CHANNEL_NOTES}"
 
           if gh release view "${CHANNEL_TAG}" >/dev/null 2>&1; then
-            gh release edit "${CHANNEL_TAG}" \
-              --title "${CHANNEL_TITLE}" \
-              --notes-file "${CHANNEL_NOTES}" \
-              ${PRERELEASE} ${LATEST}
-          else
-            gh release create "${CHANNEL_TAG}" \
-              --target "${SOURCE_SHA}" \
-              --title "${CHANNEL_TITLE}" \
-              --notes-file "${CHANNEL_NOTES}" \
-              ${PRERELEASE} ${LATEST}
+            gh release delete "${CHANNEL_TAG}" --yes
           fi
+          gh release create "${CHANNEL_TAG}" \
+            --target "${SOURCE_SHA}" \
+            --title "${CHANNEL_TITLE}" \
+            --notes-file "${CHANNEL_NOTES}" \
+            ${PRERELEASE} ${LATEST}
           gh release upload "${CHANNEL_TAG}" --clobber \
             "${CHANNEL}-CHECKSUM" "${CHANNEL}.sig" "${CHANNEL}.bundle" "${CHANNEL}.intoto.jsonl" "${CHANNEL}.json"


### PR DESCRIPTION
## What does this change?

<!-- One or two sentences. What problem does it solve or what does it add? -->

## How was it tested?

<!-- How did you verify the change works? e.g. local build, booted ISO, checked a game, ran just lint -->

## Checklist

- [x] `just lint` passes (shellcheck + shfmt)
- [x] `python3 -m unittest discover -s tests` passes
- [x] Changes to build scripts tested with `just build` or `just build-live-iso`
- [x] Major behavior changes include automated tests or a documented rationale
- [x] New packages or COPRs justified in the PR description
- [x] Breaking changes to the installer or upgrade path noted above
