### PR TITLE
Fix .mailmap identity and add dependabot mapping

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,6 @@
-mrtrick <mrtrick@users.noreply.github.com> <noreply@anthropic.com>
-mrtrick <mrtrick@users.noreply.github.com> <copilot@local>
-mrtrick <mrtrick@users.noreply.github.com> <phendrick@gmail.com>
-mrtrick <mrtrick@users.noreply.github.com> <261214137+mrtrick37@users.noreply.github.com>
+mrtrick37 <261214137+mrtrick37@users.noreply.github.com> mrtrick <261214137+mrtrick37@users.noreply.github.com>
+mrtrick37 <261214137+mrtrick37@users.noreply.github.com> <noreply@anthropic.com>
+mrtrick37 <261214137+mrtrick37@users.noreply.github.com> <copilot@local>
+mrtrick37 <261214137+mrtrick37@users.noreply.github.com> <phendrick@gmail.com>
+mrtrick37 <261214137+mrtrick37@users.noreply.github.com> <mrtrick@users.noreply.github.com>
+mrtrick37 <261214137+mrtrick37@users.noreply.github.com> <49699333+dependabot[bot]@users.noreply.github.com>


### PR DESCRIPTION
Use mrtrick37 as canonical contributor. Map Claude, Copilot, dependabot, and legacy mrtrick aliases.