### PR TITLE
fix(ci): stop Build Live ISO racing the container build it depends on

### DIFF
--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -3,12 +3,16 @@ run-name: "Build Live ISO - ${{ inputs.source_tag || github.event.workflow_run.h
 
 on:
   # Separate from container build — ISO failures no longer hide successful
-  # container publishes. Container workflow calls this via workflow_call with
-  # a pinned digest; workflow_run provides the independent retry path.
-  workflow_run: # zizmor: ignore[dangerous-triggers]
-    workflows: ["Build container image"]
-    types: [completed]
-    branches: [main, testing]
+  # container publishes. build.yml's finalize job dispatches this explicitly
+  # (workflow_dispatch, pinned digest) once the Fedora image actually
+  # publishes. There is deliberately no workflow_run trigger here: build.yml's
+  # own Validation+CodeQL gate fires "Build container image" twice per push
+  # (once per watched workflow) and the first of the two — before both checks
+  # have reported in — completes with every job skipped, which GitHub still
+  # reports as an overall success. A workflow_run listener can't tell that
+  # apart from a real publish, so it fired a doomed ISO build racing the
+  # actual one on every push. The explicit dispatch only ever fires from the
+  # leg that did real work.
   workflow_call:
     inputs:
       source_tag:
@@ -91,12 +95,6 @@ env:
 jobs:
   build:
     name: Build ISO (${{ inputs.source_tag || github.event.workflow_run.head_branch || github.ref_name || 'testing' }})
-    # The primary trigger is the explicit workflow_dispatch fired by build.yml's
-    # finalize job once the Fedora image actually publishes (pinned digest).
-    # workflow_run is only a best-effort retry path for that dispatch failing —
-    # without this gate it fires unconditionally, including when the container
-    # build itself failed, and tries to build an ISO with no image to source.
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:


### PR DESCRIPTION
build.yml's Validation+CodeQL gate fires "Build container image" twice per
push (once per watched workflow) — the first of the two completes with every
job skipped (gate said "not both ready yet") while the second does the real
build. GitHub still reports the skipped run's overall conclusion as
**success**, since no job actually failed.

`build-live-iso.yml`'s `workflow_run` listener only checked
`conclusion == 'success'`, which the skipped run satisfies just fine — so it
started an ISO build immediately, racing the real container build that
hadn't even produced an image yet, instead of waiting for it to finish. This
is exactly what was observed right after #190 merged: two "Build Live ISO"
runs fired within seconds of the corresponding "Build container image" runs
starting, both failed (no image to source).

`finalize`'s explicit `workflow_dispatch` (pinned digest) only ever fires
from the leg that did real work and is the only trigger that was ever
reliable here. Drops the `workflow_run` listener entirely rather than trying
to make it smarter — it can't distinguish "real publish" from "gate no-op"
using only the coarse overall conclusion GitHub exposes.

Also pushed to `testing` (f51a4c1), where the same trigger has existed since
before #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)