### PR TITLE
fix(ci): stop the ISO dispatch treating an explicit opt-out as opt-in

### DIFF
--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -341,7 +341,12 @@ jobs:
     # Default true from both entry points. A maintainer can dispatch with this
     # off to ship an emergency ISO, which is why publish tolerates a *skipped*
     # acceptance but never a failed one.
-    if: ${{ inputs.run_acceptance }}
+    # workflow_dispatch delivers even boolean-typed inputs as strings on the
+    # runtime `inputs` context (a long-standing GitHub Actions quirk), so a
+    # bare truthiness check here was true for the *string* "false" too --
+    # explicitly opting out via workflow_dispatch never actually skipped the
+    # job.
+    if: ${{ inputs.run_acceptance == true || inputs.run_acceptance == 'true' }}
     runs-on: ubuntu-latest
     # The script's own budget is 90m; the extra headroom covers artifact
     # download, QEMU install, and log upload on a cold runner.


### PR DESCRIPTION
## What

Applies the same fix as `testing`@1c15ed70 to `main`'s copy of `.github/workflows/build-live-iso.yml`: the `acceptance` job's `if:` was a bare truthiness check on `inputs.run_acceptance`. GitHub Actions delivers `workflow_dispatch` inputs as strings on the runtime `inputs` context even when declared `type: boolean`, so both `"true"` and `"false"` evaluated truthy.

```diff
-    if: ${{ inputs.run_acceptance }}
+    if: ${{ inputs.run_acceptance == true || inputs.run_acceptance == 'true' }}
```

## Impact on main is narrower than on testing

main's `run_acceptance` defaults to `true` (opt-in is the normal path), and `build.yml`'s automatic dispatch always passes `run_acceptance=true` explicitly — the string `"true"` was already truthy under the old check, so **the routine pipeline is unaffected by this change**.

The bug only broke the manual **opt-out** path: a maintainer dispatching by hand with `run_acceptance=false` (documented in the job's own comment as the way to "ship an emergency ISO") delivered the string `"false"`, which was also truthy — so acceptance ran anyway and the opt-out silently didn't take effect. This fix restores that opt-out.

Not a change to when acceptance runs by default, and not expected to change R2 publish behavior on main.

## Also fixed on testing

Same underlying bug, opposite-consequence default (opt-in defaults to `false` there) — see 1c15ed70 on `testing` for that side, already pushed.

## Verified

- YAML parses
- `tests.test_kyth_release_workflow_contracts` and `tests.test_kyth_build_contracts` pass against this branch's own tree (22 tests)