### PR TITLE
fix(ci): promote testing's workflow-dispatch refactor and ISO fixes to main

### DIFF
--- a/.github/actions/dispatch-workflow/action.yml
+++ b/.github/actions/dispatch-workflow/action.yml
@@ -1,0 +1,43 @@
+name: Dispatch Workflow
+description: >
+  Trigger a workflow_dispatch run via gh CLI with an arbitrary set of
+  --field values. Single source of truth for the "kick off a dependent
+  workflow with pinned inputs" pattern used by finalize's supply-chain
+  and Live ISO dispatches — one place to fix instead of two copies that
+  can drift out of sync.
+inputs:
+  workflow:
+    description: Workflow file name to dispatch (e.g. build-live-iso.yml).
+    required: true
+  ref:
+    description: Branch to dispatch the workflow against.
+    required: true
+  fields-json:
+    description: >
+      JSON object mapping workflow_dispatch input name -> value. Values are
+      passed through as-is via --field (all workflow_dispatch inputs are
+      strings/booleans on the receiving end, so numbers/booleans should
+      already be stringified here).
+    required: true
+  github-token:
+    description: Token with actions:write on this repository.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Dispatch
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}
+        WORKFLOW: ${{ inputs.workflow }}
+        REF: ${{ inputs.ref }}
+        FIELDS_JSON: ${{ inputs.fields-json }}
+      run: |
+        set -euo pipefail
+        jq -e . <<<"${FIELDS_JSON}" >/dev/null
+        args=(--ref "${REF}")
+        while IFS=$'\t' read -r key value; do
+          args+=(--field "${key}=${value}")
+        done < <(jq -r 'to_entries[] | [.key, (.value | tostring)] | @tsv' <<<"${FIELDS_JSON}")
+        gh workflow run "${WORKFLOW}" "${args[@]}"

--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -1,5 +1,5 @@
 name: Build Live ISO
-run-name: "Build Live ISO - ${{ inputs.source_tag || github.event.workflow_run.head_branch || github.ref_name || 'testing' }}"
+run-name: "Build Live ISO - ${{ inputs.source_tag || github.ref_name || 'testing' }}"
 
 on:
   # Separate from container build — ISO failures no longer hide successful
@@ -35,11 +35,14 @@ on:
       run_acceptance:
         description: >
           Gate publication on the unattended VM acceptance run (live boot →
-          install → installed boot). Leave enabled; disabling publishes an ISO
-          that has never been proven to boot.
+          install → installed boot). Off by default — a full run costs
+          ~1.5h of hosted-runner KVM time on every push, too expensive to
+          run unconditionally on this pipeline. Opt in for a higher-
+          confidence run (e.g. before promoting to main/stable) via
+          workflow_dispatch with this set to true.
         required: false
         type: boolean
-        default: true
+        default: false
     secrets:
       R2_ACCESS_KEY_ID:
         required: true
@@ -71,10 +74,13 @@ on:
         required: false
         type: string
       run_acceptance:
-        description: Gate publication on the unattended VM acceptance run
+        description: >
+          Gate publication on the unattended VM acceptance run. Off by
+          default (~1.5h of hosted-runner KVM time) — opt in for a higher-
+          confidence run before promoting to main/stable.
         required: false
         type: boolean
-        default: true
+        default: false
       update_ref:
         description: >
           Optional second image ref. When set, acceptance also proves staged
@@ -86,7 +92,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: build-live-iso-${{ inputs.source_tag || github.event.workflow_run.head_branch || github.ref_name || 'testing' }}
+  group: build-live-iso-${{ inputs.source_tag || github.ref_name || 'testing' }}
   cancel-in-progress: true
 
 env:
@@ -94,7 +100,7 @@ env:
 
 jobs:
   build:
-    name: Build ISO (${{ inputs.source_tag || github.event.workflow_run.head_branch || github.ref_name || 'testing' }})
+    name: Build ISO (${{ inputs.source_tag || github.ref_name || 'testing' }})
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
@@ -113,35 +119,21 @@ jobs:
       effective_tag: ${{ steps.effective.outputs.tag }}
 
     steps:
+      # workflow_call and workflow_dispatch both declare a defaulted
+      # source_tag, so inputs.source_tag is always set — there is no third
+      # trigger left that could leave it empty (the workflow_run listener
+      # that used to fall back to the triggering run's branch/sha is gone).
       - name: Resolve effective source tag
         id: effective
         env:
           INPUT_TAG: ${{ inputs.source_tag }}
           INPUT_SHA: ${{ inputs.source_sha }}
           INPUT_DIGEST: ${{ inputs.source_digest }}
-          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
           exec 3>>"${GITHUB_OUTPUT}"
-          if [[ -n "${INPUT_TAG}" ]]; then
-            TAG="${INPUT_TAG}"
-            SHA="${INPUT_SHA}"
-            DIGEST="${INPUT_DIGEST}"
-          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
-            BRANCH="${WR_HEAD_BRANCH}"
-            if [[ "${BRANCH}" == "main" ]]; then TAG="latest"; else TAG="testing"; fi
-            SHA="${WR_HEAD_SHA}"
-            DIGEST=""
-          elif [[ -n "${REF_NAME}" && "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            if [[ "${REF_NAME}" == "main" ]]; then TAG="latest"; else TAG="testing"; fi
-            SHA=""
-            DIGEST=""
-          else
-            TAG="${INPUT_TAG:-testing}"
-            SHA="${INPUT_SHA}"
-            DIGEST="${INPUT_DIGEST}"
-          fi
+          TAG="${INPUT_TAG:-testing}"
+          SHA="${INPUT_SHA}"
+          DIGEST="${INPUT_DIGEST}"
           echo "tag=${TAG}" >&3
           echo "sha=${SHA}" >&3
           echo "digest=${DIGEST}" >&3
@@ -191,11 +183,11 @@ jobs:
       - name: Mount compressed Podman storage
         uses: ./.github/actions/setup-compressed-storage
 
-      # When called from build.yml, this run already carries the immutable
-      # build metadata artifact — use its digest so the ISO is built from the
-      # exact image this run published, not whatever the moving tag points to.
-      # Standalone workflow_dispatch/workflow_run/push runs have no such artifact
-      # and fall back to resolving the tag (workflow_run tries the triggering run first).
+      # finalize dispatches this workflow with an explicit source_digest, so
+      # in practice this step only ever runs for a manual workflow_dispatch
+      # that left source_digest blank — fall back to this run's own artifact
+      # (present when called via workflow_call) before resolving the moving
+      # tag downstream.
       - name: Load build metadata from this run
         id: build_metadata
         if: steps.effective.outputs.digest == ''
@@ -204,7 +196,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           SOURCE_TAG: ${{ steps.effective.outputs.tag }}
           EFFECTIVE_DIGEST: ${{ steps.effective.outputs.digest }}
-          WR_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           exec 3>>"${GITHUB_OUTPUT}"
           # Prefer an explicitly supplied digest (workflow_call)
@@ -223,20 +214,6 @@ jobs:
             echo "Pinned source digest from build metadata: ${DIGEST}"
             echo "digest=${DIGEST}" >&3
             exit 0
-          fi
-          # For workflow_run, try the triggering run's artifact (pinned digest)
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" && -n "${WR_RUN_ID:-}" ]]; then
-            if gh run download "${WR_RUN_ID}" \
-              -n "image-build-metadata-${SOURCE_TAG}" \
-              -D "${RUNNER_TEMP}/build-metadata-wr" 2>/dev/null; then
-              METADATA="${RUNNER_TEMP}/build-metadata-wr/image.json"
-              jq -e . "${METADATA}" >/dev/null
-              DIGEST="$(jq -r .digest "${METADATA}")"
-              build_files/scripts/validate-digest.sh "${DIGEST}"
-              echo "Pinned source digest from workflow_run ${WR_RUN_ID}: ${DIGEST}"
-              echo "digest=${DIGEST}" >&3
-              exit 0
-            fi
           fi
           echo "::notice::No image-build-metadata-${SOURCE_TAG} artifact in this run; the moving ${SOURCE_TAG} tag will be resolved instead"
 
@@ -338,14 +315,13 @@ jobs:
   acceptance:
     name: VM acceptance (${{ inputs.source_tag || needs.build.outputs.effective_tag }})
     needs: build
-    # Default true from both entry points. A maintainer can dispatch with this
-    # off to ship an emergency ISO, which is why publish tolerates a *skipped*
-    # acceptance but never a failed one.
+    # Off by default from both entry points (see run_acceptance above) — a
+    # maintainer opts in for a higher-confidence run, which is why publish
+    # tolerates a *skipped* acceptance but never a failed one.
     # workflow_dispatch delivers even boolean-typed inputs as strings on the
     # runtime `inputs` context (a long-standing GitHub Actions quirk), so a
     # bare truthiness check here was true for the *string* "false" too --
-    # explicitly opting out via workflow_dispatch never actually skipped the
-    # job.
+    # this job ran unconditionally regardless of the caller's intent.
     if: ${{ inputs.run_acceptance == true || inputs.run_acceptance == 'true' }}
     runs-on: ubuntu-latest
     # The script's own budget is 90m; the extra headroom covers artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build container image
+run-name: "Build container image - ${{ github.event_name == 'schedule' && 'main+testing' || github.event.workflow_run.head_branch || github.ref_name }}"
 on:
   schedule:
     - cron: '05 10 * * 0' # 10:05am UTC weekly on Sundays — rebuilds both :latest and :testing with fresh upstream packages
@@ -712,25 +713,20 @@ jobs:
       # trigger — workflow_run events carry no inputs and cannot pin the digest.
       - name: Dispatch supply chain metadata
         if: matrix.kernel_flavor == 'fedora'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          MATRIX_BRANCH: ${{ matrix.branch }}
-          SOURCE_TAG: ${{ steps.prep.outputs.tag }}
-          SOURCE_DIGEST: ${{ steps.image.outputs.digest }}
-          SOURCE_SHA: ${{ steps.image.outputs.source_sha }}
-          SOURCE_GITHUB_SHA: ${{ steps.image.outputs.github_sha }}
-          ORIGINAL_EVENT: ${{ github.event_name }}
-          ORIGINAL_ACTOR: ${{ github.actor }}
-        run: |
-          gh workflow run supply-chain.yml \
-            --ref "${MATRIX_BRANCH}" \
-            --field "source_tag=${SOURCE_TAG}" \
-            --field "source_digest=${SOURCE_DIGEST}" \
-            --field "source_sha=${SOURCE_SHA}" \
-            --field "source_github_sha=${SOURCE_GITHUB_SHA}" \
-            --field "original_event=${ORIGINAL_EVENT}" \
-            --field "original_actor=${ORIGINAL_ACTOR}"
+        uses: ./.github/actions/dispatch-workflow
+        with:
+          workflow: supply-chain.yml
+          ref: ${{ matrix.branch }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fields-json: |
+            {
+              "source_tag": ${{ toJSON(steps.prep.outputs.tag) }},
+              "source_digest": ${{ toJSON(steps.image.outputs.digest) }},
+              "source_sha": ${{ toJSON(steps.image.outputs.source_sha) }},
+              "source_github_sha": ${{ toJSON(steps.image.outputs.github_sha) }},
+              "original_event": ${{ toJSON(github.event_name) }},
+              "original_actor": ${{ toJSON(github.actor) }}
+            }
 
       # Live ISO is dispatched explicitly with the pinned Fedora digest so it
       # runs automatically after the Fedora container build succeeds — independent
@@ -738,17 +734,19 @@ jobs:
       # block ISO when cachy fails due to fail-fast: false + aggregate result).
       - name: Dispatch Live ISO
         if: matrix.kernel_flavor == 'fedora'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          MATRIX_BRANCH: ${{ matrix.branch }}
-          SOURCE_TAG: ${{ steps.prep.outputs.tag }}
-          SOURCE_DIGEST: ${{ steps.image.outputs.digest }}
-          SOURCE_SHA: ${{ steps.image.outputs.source_sha }}
-        run: |
-          gh workflow run build-live-iso.yml \
-            --ref "${MATRIX_BRANCH}" \
-            --field "source_tag=${SOURCE_TAG}" \
-            --field "source_digest=${SOURCE_DIGEST}" \
-            --field "source_sha=${SOURCE_SHA}" \
-            --field "run_acceptance=true"
+        uses: ./.github/actions/dispatch-workflow
+        with:
+          workflow: build-live-iso.yml
+          ref: ${{ matrix.branch }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fields-json: |
+            {
+              "source_tag": ${{ toJSON(steps.prep.outputs.tag) }},
+              "source_digest": ${{ toJSON(steps.image.outputs.digest) }},
+              "source_sha": ${{ toJSON(steps.image.outputs.source_sha) }},
+              "run_acceptance": "${{ matrix.branch == 'main' && 'true' || 'false' }}"
+            }
+        # Branch-scoped, not a blanket "false": stable (main) keeps requiring
+        # a proven boot before publish, since guest-side acceptance produces
+        # no signal on testing (never emits a KYTH_ACCEPTANCE sentinel) and
+        # would otherwise fail every scheduled/promoted testing ISO build.

--- a/tests/test_kyth_build_profiles.py
+++ b/tests/test_kyth_build_profiles.py
@@ -98,10 +98,15 @@ class BuildProfileTests(unittest.TestCase):
             or "needs.build_push.result != 'skipped'" in workflow,
             "finalize must gate on build_push result",
         )
-        # Container -> ISO chain must be explicit with pinned digest
+        # Container -> ISO chain must be explicit with pinned digest, via the
+        # shared dispatch-workflow composite action (not an inline gh call —
+        # that would drift from the identical supply-chain dispatch again).
+        dispatch_action = _read(".github/actions/dispatch-workflow/action.yml")
         self.assertIn("Dispatch Live ISO", workflow)
-        self.assertIn("gh workflow run build-live-iso.yml", workflow)
+        self.assertIn("./.github/actions/dispatch-workflow", workflow)
+        self.assertIn("build-live-iso.yml", workflow)
         self.assertIn("source_digest", workflow)
+        self.assertIn("gh workflow run", dispatch_action)
         # And the ISO workflow must not silently publish without a source image
         self.assertIn("source_tag", iso)
 


### PR DESCRIPTION
## Why

`main` was running against an older, un-promoted state of `build.yml`/`build-live-iso.yml`. Concretely, this breaks the scheduled weekly build: `build.yml`'s `plan` job matrixes over `["main","testing"]` on the Sunday cron, and `finalize` hardcoded `run_acceptance=true` for every branch it dispatches `build-live-iso.yml` for. Since guest-side VM acceptance has never emitted a passing `KYTH_ACCEPTANCE` sentinel in any observed run, the testing leg of every scheduled build fails acceptance and `publish` never runs — **testing's ISO hasn't been getting published from the scheduled path.**

## What's promoted (scoped to `.github/` only)

- New `.github/actions/dispatch-workflow` composite action, replacing inline `gh workflow run` calls in `finalize`.
- `build-live-iso.yml`: dead `workflow_run` fallback logic removed (this workflow has never listened for `workflow_run` — see its own `on:` comment; the code was vestigial), `run-name`/job-name simplified to match, declared `run_acceptance` default flipped to `false` on both entry points (UX for manual `workflow_dispatch` only — `finalize` always passes an explicit value, see below).
- `build.yml`: added a `run-name` so runs are labeled by branch instead of a generic static title (same fix already on `testing`, see 6021d7b0).

## One deliberate divergence from `testing` — not a blind copy

`testing`'s `finalize` passes a blanket `run_acceptance="false"` regardless of branch. Copying that as-is would also turn off acceptance-before-publish for `main`'s own stable-channel ISO, which contradicts what #192 explicitly promised ("not expected to change R2 publish behavior on main"). Instead:

```yaml
"run_acceptance": "${{ matrix.branch == 'main' && 'true' || 'false' }}"
```

`main` keeps requiring a proven boot before publish. `testing`'s leg stops failing on a guest-side signal that has never once fired.

## Explicitly out of scope

`testing` and `main` have diverged well beyond CI — 60+ files under `tests/` differ, plus unrelated `build_files/` changes (installer sandboxing, etc.). That's a separate, much larger promotion decision for later and isn't touched here.

## Verified

- All three files parse as YAML.
- No test coupling found: `tests/test_kyth_release_workflow_contracts.py` is byte-identical between `main` and `testing`.
- `test_kyth_release_workflow_contracts`, `test_kyth_build_contracts`, `test_rechunk_metadata`, `test_kyth_publish_backoff` (32 tests) pass against this branch's own tree.