### PR TITLE
fix(guardian): make self-heal actually persist, apply, and stay useful

### DIFF
--- a/build_files/kyth-guardian.service
+++ b/build_files/kyth-guardian.service
@@ -36,8 +36,16 @@ SystemCallArchitectures=native
 CapabilityBoundingSet=
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 UMask=0077
+# ProtectSystem=strict makes the whole tree read-only. Without StateDirectory
+# the timer cannot write XDG_STATE_HOME/kyth/guardian.json, so occurrence
+# counters never survive a run and background auto-fix never reaches the
+# two-consecutive-failure gate.
+StateDirectory=kyth
+StateDirectoryMode=0700
 CacheDirectory=kyth
 CacheDirectoryMode=0700
+# flatpak --user metadata refresh (automatic recipe) writes here.
+ReadWritePaths=-%h/.local/share/flatpak -%h/.cache/flatpak
 
 [Install]
 WantedBy=default.target

--- a/docs/guardian.md
+++ b/docs/guardian.md
@@ -28,7 +28,10 @@ profile and leaving it disconnected is not treated as a fault.
 The user timer performs a bounded check every 15 minutes, while a systemd path
 unit reacts when the shared user probe cache changes. Both start a oneshot
 process; nothing polls continuously. The service runs at low CPU and I/O
-priority with memory and CPU limits.
+priority with memory and CPU limits. `ProtectSystem=strict` is paired with
+`StateDirectory=kyth` so occurrence counters and history actually survive a
+timer run — without that, background auto-fix can never reach two consecutive
+failures.
 
 Recipes (allowlist). Background auto-fix still requires `risk=safe`, no auth, two
 consecutive failures, and a cooldown. **Fix My System** / `kyth-guardian fix`
@@ -47,7 +50,7 @@ low battery, and thermal pressure still pause execution.
 | `flatpak.refresh-metadata` | Refresh Flatpak metadata | safe | yes | 30m |
 | `portal.restart-user` | Restart desktop portals | safe | yes | 15m |
 | `plasma.restart-user` | Restart Plasma shell | safe | yes | 15m |
-| `storage.maint` | Run storage maintenance (gated scrub/balance) | safe | yes | 24h |
+| `storage.maint` | Run storage maintenance (gated scrub/balance) | safe | no | 24h |
 | `firmware.refresh` | Refresh firmware metadata (flock) | safe | yes | 12h |
 | `display.reconfigure` | Re-apply display outputs | safe | yes | 6h |
 | `power.profile-fix` | Reset power profile | safe | yes | 1h |
@@ -81,9 +84,11 @@ System Hub exposes controls on **System → Guardian** (self-healing dashboard).
 
 ```bash
 kyth-guardian --json status
+kyth-guardian --json inspect
 kyth-guardian --json check
 kyth-guardian --json investigate
 kyth-guardian --json fix
+kyth-guardian --json fix audio.restart
 kyth-guardian --json history
 kyth-guardian enable
 kyth-guardian disable
@@ -92,7 +97,16 @@ kyth-guardian model install
 kyth-guardian model remove
 ```
 
-`check` is the timer path (auto-fix only after two consecutive failures). `fix`
-is the user-initiated path used by System Hub → Guardian → Fix My System.
+`check` is the timer path (auto-fix only after two consecutive failures). `inspect`
+is the read-only snapshot used by System Hub live health — it never writes
+history or occurrence counters, so opening the page cannot accelerate auto-fix.
+`fix` is the user-initiated path used by System Hub → Guardian → Fix My System
+or a per-recipe **Apply** button. Optional recipe ids apply that repair now:
+
+```bash
+kyth-guardian --json inspect
+kyth-guardian --json fix
+kyth-guardian --json fix audio.restart
+```
 
 The global `--json` option precedes the command.

--- a/src/kyth-welcome/kyth_welcome/page_guardian.py
+++ b/src/kyth-welcome/kyth_welcome/page_guardian.py
@@ -24,7 +24,7 @@ from .qt import (
     Qt,
     single_shot,
 )
-from .widgets import Page, _make_card, _make_tip_card
+from .widgets import Page, _make_card
 
 # ---------------------------------------------------------------------------
 # helpers — run on background threads (DataWorker) so Hub never blocks
@@ -47,10 +47,24 @@ def _guardian_history() -> dict:
         return {"history": [], "error": str(exc)}
 
 
+def _guardian_inspect() -> dict:
+    """Live snapshot — never writes history or occurrence counters."""
+    try:
+        from kyth_shared.guardian import inspect as _inspect
+        return _inspect()
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc), "symptoms": [], "decisions": []}
+
+
 def _guardian_check(*, investigate: bool = False) -> dict:
     try:
         from kyth_shared.guardian import check as _check
-        return _check(investigate=investigate, automatic=False)
+        return _check(
+            investigate=investigate,
+            automatic=False,
+            persist=True,
+            count_failures=False,
+        )
     except Exception as exc:  # noqa: BLE001
         return {"error": str(exc), "symptoms": [], "decisions": []}
 
@@ -60,6 +74,20 @@ def _guardian_fix_my_system() -> dict:
     try:
         from kyth_shared.guardian import check as _check
         return _check(investigate=False, automatic=True, user_initiated=True)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc), "symptoms": [], "decisions": []}
+
+
+def _guardian_apply(recipe_id: str) -> dict:
+    try:
+        from kyth_shared.guardian import check as _check
+        return _check(
+            investigate=False,
+            automatic=True,
+            user_initiated=True,
+            recipe_ids={recipe_id},
+            force_recipe_ids={recipe_id},
+        )
     except Exception as exc:  # noqa: BLE001
         return {"error": str(exc), "symptoms": [], "decisions": []}
 
@@ -121,6 +149,7 @@ class GuardianPage(Page):
         self._model_worker = None
         self._check_worker = None
         self._toggle_worker = None
+        self._apply_worker = None
 
         self._page_header(
             "System",
@@ -131,7 +160,6 @@ class GuardianPage(Page):
 
         self._build_status_card()
         self._build_health_card()
-        self._build_dashboard_card()
         self._build_history_card()
         self._build_recipes_card()
         self._build_model_card()
@@ -151,8 +179,7 @@ class GuardianPage(Page):
         intro = QLabel(
             "Guardian watches audio, portals, Plasma shell, network, Bluetooth, Flatpak, storage, "
             "display, controllers, power, and update health. Cheap checks run every 15 minutes and again "
-            "when the system probe cache changes. The optional local model starts only when a case is "
-            "ambiguous, picks one Kyth recipe, then exits."
+            "when the system probe cache changes. Opening this page does not count toward auto-fix."
         )
         intro.setObjectName("card-copy")
         intro.setWordWrap(True)
@@ -226,6 +253,12 @@ class GuardianPage(Page):
         self._health_lbl.setWordWrap(True)
         layout.addWidget(self._health_lbl)
 
+        self._symptom_box = QWidget()
+        self._symptom_layout = QVBoxLayout(self._symptom_box)
+        self._symptom_layout.setContentsMargins(0, 0, 0, 0)
+        self._symptom_layout.setSpacing(6)
+        layout.addWidget(self._symptom_box)
+
         self._decisions_lbl = QLabel("")
         self._decisions_lbl.setObjectName("card-copy")
         self._decisions_lbl.setWordWrap(True)
@@ -252,43 +285,6 @@ class GuardianPage(Page):
 
         self._add(card)
 
-    # -- health dashboard --------------------------------------------------
-
-    def _build_dashboard_card(self) -> None:
-        card, layout = _make_card("card-accent-ok")
-        title = QLabel("Health dashboard — super-app at a glance")
-        title.setObjectName("card-title")
-        layout.addWidget(title)
-        intro = QLabel(
-            "All Guardian healing plus StarTER packs, Installed, and updates live in this one System Hub — no store hop. "
-            "This dashboard surfaces what auto-healed, what needs you, and when gaming/battery paused it."
-        )
-        intro.setObjectName("card-copy")
-        intro.setWordWrap(True)
-        layout.addWidget(intro)
-        self._dash_health = QLabel("Loading dashboard…")
-        self._dash_health.setObjectName("card-copy")
-        self._dash_health.setWordWrap(True)
-        self._dash_health.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-        layout.addWidget(self._dash_health)
-        self._dash_chain = QLabel("")
-        self._dash_chain.setObjectName("card-copy")
-        self._dash_chain.setWordWrap(True)
-        self._dash_chain.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-        layout.addWidget(self._dash_chain)
-        row = QHBoxLayout()
-        row.setSpacing(8)
-        hub_btn = QPushButton("Open Software → Starter Packs")
-        hub_btn.setToolTip("Opt-in apps and starter packs — all in this same Hub")
-        hub_btn.clicked.connect(lambda _=False: self._navigate("App Store"))
-        row.addWidget(hub_btn)
-        upd_btn = QPushButton("Open System → Updates")
-        upd_btn.clicked.connect(lambda _=False: self._navigate("Update"))
-        row.addWidget(upd_btn)
-        row.addStretch()
-        layout.addLayout(row)
-        self._add(card)
-
     # -- history -----------------------------------------------------------
 
     def _build_history_card(self) -> None:
@@ -307,10 +303,18 @@ class GuardianPage(Page):
         self._history_summary.setWordWrap(True)
         layout.addWidget(self._history_summary)
 
+        self._history_list = QWidget()
+        self._history_list_layout = QVBoxLayout(self._history_list)
+        self._history_list_layout.setContentsMargins(0, 0, 0, 0)
+        self._history_list_layout.setSpacing(8)
+        layout.addWidget(self._history_list)
+
         self._history_view = QTextEdit()
         self._history_view.setReadOnly(True)
-        self._history_view.setMinimumHeight(180)
-        self._history_view.setPlaceholderText("History will appear here as JSON — copy, save, or clear from the buttons below.")
+        self._history_view.setMinimumHeight(120)
+        self._history_view.setMaximumHeight(180)
+        self._history_view.setPlaceholderText("Raw JSON (last 25 records) — copy if you are filing a report.")
+        self._history_view.document().setMaximumBlockCount(400)
         layout.addWidget(self._history_view)
 
         row = QHBoxLayout()
@@ -505,12 +509,7 @@ class GuardianPage(Page):
         self._status_lbl.setObjectName("status-ok" if enabled else "card-copy")
         restyle(self._status_lbl)
 
-        # suppression banner (from check's suppression_reason — also expose here via quick probe)
-        try:
-            from kyth_shared.guardian import suppression_reason
-            reason = suppression_reason()
-        except Exception:
-            reason = ""
+        reason = str(data.get("suppression_reason") or "")
         if reason:
             self._suppression_lbl.setText(f"Paused — {reason} (checks resume automatically)")
             self._suppression_lbl.show()
@@ -522,8 +521,10 @@ class GuardianPage(Page):
         if recipes:
             lines = []
             for r in recipes:
-                badge = "safe/auto" if r.get("risk") == "safe" and not r.get("requires_auth") else r.get("risk", "")
-                lines.append(f"• {r.get('id')} — {r.get('title')}  [{badge}]")
+                badge = "safe/auto" if r.get("risk") == "safe" and r.get("automatic") and not r.get("requires_auth") else r.get("risk", "")
+                rec = str(r.get("recovery") or "").strip()
+                extra = f" — {rec}" if rec else ""
+                lines.append(f"• {r.get('id')} — {r.get('title')}  [{badge}]{extra}")
             self._recipes_lbl.setText("\n".join(lines))
         else:
             self._recipes_lbl.setText("No recipes reported.")
@@ -558,7 +559,7 @@ class GuardianPage(Page):
     def _refresh_health_preview(self) -> None:
         if self._health_worker is not None:
             return
-        self._health_worker = DataWorker("guardian-preview", lambda: _guardian_check(investigate=False))
+        self._health_worker = DataWorker("guardian-preview", _guardian_inspect)
         self._health_worker.result.connect(guard_disposed(self._on_health_ready))
         self._health_worker.failed.connect(guard_disposed(lambda _k, m: self._health_lbl.setText(f"Preview failed: {m}")))
         self._health_worker.finished.connect(lambda: setattr(self, "_health_worker", None))
@@ -570,6 +571,7 @@ class GuardianPage(Page):
             return
         if data.get("error"):
             self._health_lbl.setText(f"Live check failed: {data['error']}")
+            self._clear_layout(self._symptom_layout)
             return
         symptoms = data.get("symptoms", [])
         decisions = data.get("decisions", [])
@@ -581,19 +583,20 @@ class GuardianPage(Page):
             self._health_lbl.setText("Healthy — no issues detected. Guardian stays quiet until something drifts.")
             self._health_lbl.setObjectName("status-ok")
         else:
-            parts = []
-            for s in symptoms if isinstance(symptoms, list) else []:
-                if isinstance(s, dict):
-                    parts.append(f"• {s.get('component')}: {s.get('evidence','')[:160]}  → {', '.join(s.get('recipes',()))}")
-            self._health_lbl.setText("\n".join(parts) if parts else f"{len(symptoms)} symptom(s) detected.")
+            count = len(symptoms) if isinstance(symptoms, list) else 0
+            self._health_lbl.setText(f"{count} issue(s) — apply one below, or use Fix My System for all eligible repairs.")
             self._health_lbl.setObjectName("status-warn")
         restyle(self._health_lbl)
+        self._render_symptom_rows(symptoms if isinstance(symptoms, list) else [], suppressed=bool(suppressed))
 
         if isinstance(decisions, list) and decisions:
             lines = []
             for d in decisions[:5]:
                 if isinstance(d, dict):
-                    lines.append(f"→ {d.get('recipe_id')} [{d.get('source')}, {d.get('confidence')}] — {d.get('action')} — {d.get('detail','')[:120]}")
+                    lines.append(
+                        f"→ {d.get('recipe_id')} [{d.get('source')}, {d.get('confidence')}] "
+                        f"— {d.get('action')} — {str(d.get('detail', ''))[:120]}"
+                    )
             steps = data.get("next_steps") if isinstance(data.get("next_steps"), list) else []
             recoveries = [
                 str(s.get("recovery"))
@@ -603,14 +606,54 @@ class GuardianPage(Page):
             if recoveries:
                 lines.append("Next: " + recoveries[0][:180])
             self._decisions_lbl.setText("\n".join(lines))
+        elif not symptoms:
+            self._decisions_lbl.setText("No repair queued — checks re-run every 15 minutes and when system probes change.")
         else:
-            self._decisions_lbl.setText("No repair queued — checks will re-run on the next timer tick or when system probes change.")
+            self._decisions_lbl.setText("")
         restyle(self._decisions_lbl)
-        # update dashboard mirror
-        try:
-            self._update_dashboard_preview(data, symptoms)
-        except Exception:
-            pass
+
+    def _clear_layout(self, layout) -> None:
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            child = item.layout()
+            if widget is not None:
+                widget.deleteLater()
+            elif child is not None:
+                self._clear_layout(child)
+
+    def _render_symptom_rows(self, symptoms: list, *, suppressed: bool) -> None:
+        self._clear_layout(self._symptom_layout)
+        from kyth_shared.guardian import RECIPES
+
+        for symptom in symptoms:
+            if not isinstance(symptom, dict):
+                continue
+            recipes = [rid for rid in (symptom.get("recipes") or ()) if rid]
+            recipe_id = recipes[0] if recipes else ""
+            recipe = RECIPES.get(recipe_id)
+            row = QWidget()
+            row_layout = QHBoxLayout(row)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+            row_layout.setSpacing(8)
+            copy = QLabel(
+                f"{symptom.get('component')}: {str(symptom.get('evidence', ''))[:160]}"
+            )
+            copy.setObjectName("card-copy")
+            copy.setWordWrap(True)
+            row_layout.addWidget(copy, 1)
+            if recipe is not None and recipe.risk in {"safe", "confirm"}:
+                btn = QPushButton("Apply")
+                title = recipe.title
+                if recipe.requires_auth:
+                    btn.setText("Apply…")
+                    btn.setToolTip(f"{title} — may ask for permission. Paused during gaming, capture, updates, low battery, or thermal pressure.")
+                else:
+                    btn.setToolTip(f"{title}. Paused during gaming, capture, updates, low battery, or thermal pressure.")
+                btn.setEnabled(not suppressed and self._apply_worker is None)
+                btn.clicked.connect(lambda _=False, rid=recipe.id: self._run_apply(rid))
+                row_layout.addWidget(btn)
+            self._symptom_layout.addWidget(row)
 
     def _refresh_history(self) -> None:
         if self._history_worker is not None:
@@ -622,44 +665,6 @@ class GuardianPage(Page):
         self._history_worker.finished.connect(self._history_worker.deleteLater)
         self._history_worker.start()
 
-    def _update_dashboard_preview(self, check_data: dict, symptoms: list) -> None:
-        if not hasattr(self, "_dash_health"):
-            return
-        suppressed = check_data.get("suppression_reason", "")
-        if suppressed:
-            self._dash_health.setText(f"Guardian paused — {suppressed} (gaming/battery/thermal) · checks resume automatically")
-            self._dash_health.setObjectName("status-warn")
-        elif not symptoms:
-            self._dash_health.setText("Healthy — all probes ok · Storage ok · Firmware ok · Audio/Network ok")
-            self._dash_health.setObjectName("status-ok")
-        else:
-            comps = ", ".join(sorted({s.get("component","?") for s in symptoms if isinstance(s, dict)}))
-            self._dash_health.setText(f"Needs attention: {comps} — see Live health below. Heap: Starter Packs + Opt-in apps stay in System Hub.")
-            self._dash_health.setObjectName("status-warn")
-        restyle(self._dash_health)
-        # chain timeline from history if available
-        try:
-            from kyth_shared.guardian import load_state
-            hist = load_state().get("history", [])
-            chains = [h for h in hist if isinstance(h, dict) and "chain" in h]
-            if chains:
-                last = chains[-1]
-                ts = _fmt_ts(last.get("timestamp"))
-                chain_ids = last.get("chain", [])
-                results = last.get("results", [])
-                ok_n = sum(1 for r in results if r.get("verified"))
-                self._dash_chain.setText(f"Last healing chain {ts}: {' → '.join(chain_ids)} · verified {ok_n}/{len(results)} · see History")
-            else:
-                # show last 2 single actions
-                hist2 = [h for h in hist if isinstance(h, dict) and h.get("recipe_id")][-2:]
-                if hist2:
-                    self._dash_chain.setText("Recent: " + " · ".join(f"{h.get('recipe_id')} @ {_fmt_ts(h.get('timestamp'))}" for h in hist2))
-                else:
-                    self._dash_chain.setText("No healing chains yet — background auto-fix waits for two consecutive failures. Use Fix My System to apply safe repairs now.")
-            restyle(self._dash_chain)
-        except Exception:
-            pass
-
     def _on_history_ready(self, _key: str, data: object) -> None:
         if not isinstance(data, dict):
             return
@@ -667,15 +672,75 @@ class GuardianPage(Page):
         if not isinstance(history, list):
             history = []
         last = _fmt_ts(data.get("last_check"))
-        self._history_summary.setText(f"{len(history)} record(s) · last check {last} — newest last, rotated after 100 / 30 days.")
+        self._history_summary.setText(
+            f"{len(history)} record(s) · last check {last} — newest last, rotated after 100 / 30 days."
+        )
+        self._render_history_list(history)
         try:
             pretty = json.dumps(history[-25:], indent=2, sort_keys=True, ensure_ascii=False) if history else "[]"
         except (OSError, ValueError, TypeError):
             pretty = str(history[-25:])
-        # avoid flooding the widget on huge history
         if len(pretty) > 20000:
             pretty = pretty[-20000:]
         self._history_view.setPlainText(pretty)
+
+    def _render_history_list(self, history: list) -> None:
+        self._clear_layout(self._history_list_layout)
+        from kyth_shared.guardian import RECIPES
+
+        recent = [item for item in history if isinstance(item, dict)][-8:][::-1]
+        if not recent:
+            empty = QLabel("No recent auto-repairs — system is healthy, or monitoring has not run yet.")
+            empty.setObjectName("card-copy")
+            self._history_list_layout.addWidget(empty)
+            return
+        now = time.time()
+        for item in recent:
+            rid = item.get("recipe_id") or (item.get("chain", [None])[0] if item.get("chain") else "unknown")
+            rec = RECIPES.get(rid)
+            title = rec.title if rec else str(rid)
+            try:
+                age = now - float(item.get("timestamp", 0))
+                if age < 3600:
+                    when = f"{int(age // 60)}m ago"
+                elif age < 86400:
+                    when = f"{int(age // 3600)}h ago"
+                else:
+                    when = f"{int(age // 86400)}d ago"
+            except (ValueError, TypeError):
+                when = "recently"
+            verified = item.get("verified")
+            if verified is True:
+                vtxt = "verified"
+            elif verified is False:
+                vtxt = "not verified"
+            else:
+                vtxt = str(item.get("action") or "")
+            row = QLabel(f"{when} — {title} ({vtxt})")
+            row.setObjectName("card-copy")
+            row.setWordWrap(True)
+            self._history_list_layout.addWidget(row)
+            detail = (item.get("detail") or item.get("explanation") or "")[:200]
+            if detail:
+                d = QLabel(detail)
+                d.setObjectName("caption-text")
+                d.setWordWrap(True)
+                self._history_list_layout.addWidget(d)
+            if rid and rec is not None:
+                fb_row = QHBoxLayout()
+                fb_row.setSpacing(6)
+                fb_lbl = QLabel("Did this help?")
+                fb_lbl.setObjectName("caption-text")
+                fb_row.addWidget(fb_lbl)
+                for label, helpful in (("Yes", True), ("No", False)):
+                    btn = QPushButton(label)
+                    btn.setToolTip("Teach Guardian for next time (local only)")
+                    btn.clicked.connect(
+                        lambda _=False, recipe_id=str(rid), value=helpful: self._record_feedback(recipe_id, value)
+                    )
+                    fb_row.addWidget(btn)
+                fb_row.addStretch()
+                self._history_list_layout.addLayout(fb_row)
 
     def _run_check(self, *, investigate: bool) -> None:
         if self._check_worker is not None:
@@ -782,13 +847,38 @@ class GuardianPage(Page):
                 self._fix_status.setText("Healthy — no repairs needed.")
                 self._fix_status.setObjectName("status-ok")
         restyle(self._fix_status)
-        # mirror to health + refresh history/dashboard
         try:
             self._on_health_ready(_key, data)
         except Exception:
             pass
         single_shot(self, 200, self._refresh_history)
         single_shot(self, 200, self._refresh_status)
+        single_shot(self, 400, self._refresh_health_preview)
+
+    def _run_apply(self, recipe_id: str) -> None:
+        if self._apply_worker is not None:
+            return
+        self._fix_status.setText(f"Applying {recipe_id}…")
+        self._fix_btn.setEnabled(False)
+        self._apply_worker = DataWorker(f"guardian-apply-{recipe_id}", lambda: _guardian_apply(recipe_id))
+        self._apply_worker.result.connect(guard_disposed(self._on_apply_done))
+        self._apply_worker.failed.connect(guard_disposed(lambda _k, m: self._on_apply_done(_k, {"error": m})))
+        self._apply_worker.finished.connect(lambda: setattr(self, "_apply_worker", None))
+        self._apply_worker.finished.connect(self._apply_worker.deleteLater)
+        self._apply_worker.start()
+
+    def _on_apply_done(self, _key: str, data: object) -> None:
+        self._on_fix_done(_key, data)
+
+    def _record_feedback(self, recipe_id: str, helpful: bool) -> None:
+        try:
+            from kyth_shared.guardian import record_feedback
+            record_feedback(recipe_id, helpful)
+        except Exception as exc:  # noqa: BLE001
+            self._history_summary.setText(f"Could not save feedback: {exc}")
+            return
+        self._history_summary.setText("Thanks — Guardian will weigh that the next time this recipe comes up.")
+        restyle(self._history_summary)
 
     def _copy_history(self) -> None:
         text = self._history_view.toPlainText()

--- a/src/kyth_shared/kyth_shared/guardian.py
+++ b/src/kyth_shared/kyth_shared/guardian.py
@@ -129,8 +129,8 @@ RECIPES: dict[str, Recipe] = {
         Recipe("disk.review", "Review storage usage", "storage", tuple(),
                "advisory", False, False, 3600, "storage", "Open System Hub > Hardware > Storage; Guardian never deletes files."),
         Recipe("storage.maint", "Run storage maintenance", "storage",
-               ("bash", "-c", "/usr/libexec/kyth-storage-gate && /usr/bin/kyth-btrfs-maint"),
-               "safe", False, True, 86400, "storage", "Gated btrfs scrub/balance (AC+idle+!gaming); safe to retry."),
+               ("/usr/libexec/kyth-storage-gate",),
+               "safe", False, False, 86400, "storage", "Gated btrfs scrub/balance (AC+idle+!gaming). Not a timer auto-fix — a scrub can outlive the 90s oneshot."),
         Recipe("firmware.refresh", "Refresh firmware metadata", "firmware",
                ("flock", "-w", "10", "/run/kyth-fwupd.lock", "fwupdmgr", "refresh", "--force"),
                "safe", False, True, 43200, "firmware", "Refreshes LVFS metadata only; does not flash devices."),
@@ -248,10 +248,68 @@ def _active(unit: str, *, user: bool = False) -> bool:
     return bool(result and result.returncode == 0)
 
 
-def _unit_loaded(unit: str, *, user: bool = False) -> bool:
+def _unit_loaded(unit: str, *, user: bool = False) -> bool | None:
+    """True/False when systemd answers; None if the probe itself failed."""
     command = ["systemctl"] + (["--user"] if user else []) + ["show", "-p", "LoadState", "--value", unit]
     result = _run(command, 4)
-    return bool(result and (result.stdout or "").strip() == "loaded")
+    if result is None:
+        return None
+    state = (result.stdout or "").strip()
+    if not state:
+        return None
+    return state == "loaded"
+
+
+def _in_graphical_session() -> bool:
+    """Skip session-scoped probes on a tty/SSH login with no display."""
+    if os.environ.get("WAYLAND_DISPLAY") or os.environ.get("DISPLAY"):
+        return True
+    session = os.environ.get("XDG_SESSION_TYPE", "").strip().lower()
+    if session in {"wayland", "x11"}:
+        return True
+    if session in {"tty", "unspecified", "none"}:
+        return False
+    # User timers after graphical login often lack WAYLAND_DISPLAY in env.
+    return True
+
+
+def _bluetooth_adapter_present() -> bool:
+    root = Path("/sys/class/bluetooth")
+    if not root.exists():
+        return False
+    try:
+        return any(root.iterdir())
+    except OSError:
+        return False
+
+
+def _bluetooth_soft_blocked() -> bool:
+    """True when the user (or a hardware switch) has Bluetooth soft-blocked."""
+    try:
+        for path in Path("/sys/class/rfkill").glob("rfkill*"):
+            try:
+                if (path / "type").read_text(encoding="utf-8").strip() != "bluetooth":
+                    continue
+                if (path / "soft").read_text(encoding="utf-8").strip() == "1":
+                    return True
+            except OSError:
+                continue
+    except OSError:
+        return False
+    return False
+
+
+def _firmware_needs_metadata_refresh(returncode: int, stdout: str, stderr: str) -> bool:
+    """fwupdmgr get-updates: 0 = listed, 2 = nothing to do. Only metadata errors are a fault."""
+    if returncode in {0, 2}:
+        return False
+    blob = f"{stderr} {stdout}".lower()
+    if any(token in blob for token in ("no detected", "no upgrades", "nothing to do", "no updates")):
+        return False
+    return any(
+        token in blob
+        for token in ("metadata", "lvfs", "failed to download", "cannot refresh", "not up to date", "stale")
+    )
 
 
 def _probe_collect(name: str, collector: Callable[[], list[Symptom] | None]) -> list[Symptom]:
@@ -299,6 +357,13 @@ def _probe_network() -> list[Symptom]:
 
 
 def _probe_bluetooth() -> list[Symptom]:
+    if not _bluetooth_adapter_present():
+        return []
+    if _bluetooth_soft_blocked():
+        return []
+    loaded = _unit_loaded("bluetooth.service", user=False)
+    if loaded is False:
+        return []
     if not _active("bluetooth.service"):
         return [Symptom("bluetooth", "Bluetooth service is inactive", ("bluetooth.restart",))]
     return []
@@ -309,6 +374,9 @@ def _probe_portal() -> list[Symptom]:
     # xdg-desktop-portal-kde.service name — either backend is healthy.
     from .system.desktop_stack import PORTAL_KDE_UNITS, PORTAL_UNITS
 
+    loaded = _unit_loaded("xdg-desktop-portal.service", user=True)
+    if loaded is False:
+        return []
     down: list[str] = []
     for unit in PORTAL_UNITS:
         if not _active(unit, user=True):
@@ -321,6 +389,9 @@ def _probe_portal() -> list[Symptom]:
 
 
 def _probe_plasma() -> list[Symptom]:
+    loaded = _unit_loaded("plasma-plasmashell.service", user=True)
+    if loaded is False:
+        return []
     if not _active("plasma-plasmashell.service", user=True):
         return [Symptom("plasma", "Plasma shell service is inactive", ("plasma.restart-user",))]
     return []
@@ -361,35 +432,40 @@ def _probe_storage() -> list[Symptom]:
 
 def _probe_firmware() -> list[Symptom]:
     fw = _run(("fwupdmgr", "get-updates"), 8)
-    if fw and fw.returncode != 0 and "No detected" not in (fw.stdout or ""):
-        return [Symptom("firmware", f"Firmware metadata refresh needed: {(fw.stderr or '').strip()[:120]}",
-                        ("firmware.refresh",))]
-    return []
+    if not fw:
+        return []
+    if not _firmware_needs_metadata_refresh(fw.returncode, fw.stdout or "", fw.stderr or ""):
+        return []
+    return [Symptom("firmware", f"Firmware metadata refresh needed: {(fw.stderr or fw.stdout or '').strip()[:120]}",
+                    ("firmware.refresh",))]
 
 
 def _probe_display() -> list[Symptom]:
+    if not _in_graphical_session():
+        return []
     kd = _run(("kscreen-doctor", "-o"), 5)
     if kd is None:
         return []
     if kd.returncode != 0:
-        return [Symptom("display", f"kscreen-doctor failed: {(kd.stderr or '').strip()[:80]}",
+        err = (kd.stderr or kd.stdout or "").strip()
+        lowered = err.lower()
+        if any(token in lowered for token in ("not running", "could not connect", "display server", "unable to")):
+            return []
+        return [Symptom("display", f"kscreen-doctor failed: {err[:80]}", ("display.reconfigure",))]
+    from .guardian_actions import parse_kscreen_outputs
+    outputs = parse_kscreen_outputs(kd.stdout or "")
+    if not outputs:
+        return []
+    disabled = [str(item.get("name") or "") for item in outputs
+                if item.get("connected") and not item.get("enabled") and item.get("name")]
+    if disabled:
+        return [Symptom("display", f"Connected output(s) disabled: {', '.join(disabled[:4])}",
                         ("display.reconfigure",))]
-    out = kd.stdout or ""
-    if " connected" not in out or "enabled" not in out.lower():
-        return [Symptom("display", "Display output not correctly enabled after dock", ("display.reconfigure",))]
-    if "No such" in out or "Failed" in out:
-        return [Symptom("display", "kscreen-doctor reports display error", ("display.reconfigure",))]
     return []
 
 
 def _probe_controller() -> list[Symptom]:
-    if not Path("/sys/class/bluetooth").exists():
-        return []
-    try:
-        has_bt = any(Path("/sys/class/bluetooth").iterdir())
-    except OSError:
-        return []
-    if not has_bt:
+    if not _bluetooth_adapter_present():
         return []
     if not _unit_loaded("joycond.service", user=False):
         return []
@@ -411,12 +487,15 @@ def _probe_power() -> list[Symptom]:
     pp = _run(("powerprofilesctl", "get"), 4)
     if pp is None:
         return []
-    if pp.returncode != 0 and "No power" not in (pp.stdout or ""):
-        return [Symptom("power", f"Power profile unavailable: {(pp.stderr or '').strip()[:80]}",
+    if pp.returncode != 0:
+        err = (pp.stderr or pp.stdout or "")
+        if "No power" in err or "not available" in err.lower():
+            return []
+        return [Symptom("power", f"Power profile unavailable: {err.strip()[:80]}",
                         ("power.profile-fix",))]
-    if pp.returncode == 0 and (pp.stdout or "").strip() not in {"balanced", "performance", "power-saver"}:
-        return [Symptom("power", f"Power profile unexpected: {(pp.stdout or '').strip()[:40]}",
-                        ("power.profile-fix",))]
+    # Any named profile is fine — vendors ship custom names beyond the trio.
+    if not (pp.stdout or "").strip():
+        return [Symptom("power", "Power profile unset", ("power.profile-fix",))]
     return []
 
 
@@ -868,7 +947,15 @@ def verify_recipe(recipe_id: str) -> bool:
         return _active("plasma-plasmashell.service", user=True)
     if recipe.verification == "display":
         kd = _run(("kscreen-doctor", "-o"), 5)
-        return bool(kd and kd.returncode == 0 and " connected" in (kd.stdout or "") and "enabled" in (kd.stdout or "").lower())
+        if not kd or kd.returncode != 0:
+            return False
+        from .guardian_actions import parse_kscreen_outputs
+        outputs = parse_kscreen_outputs(kd.stdout or "")
+        if not outputs:
+            return "enabled" in (kd.stdout or "").lower()
+        return any(item.get("connected") for item in outputs) and not any(
+            item.get("connected") and not item.get("enabled") for item in outputs
+        )
     if recipe.verification == "controller":
         return _active("joycond.service", user=False)
     if recipe.verification == "storage":
@@ -882,7 +969,7 @@ def verify_recipe(recipe_id: str) -> bool:
             return False
     if recipe.verification == "firmware":
         fw = _run(("fwupdmgr", "get-updates"), 8)
-        return bool(fw and fw.returncode == 0)
+        return bool(fw and fw.returncode in {0, 2})
     if recipe.verification == "power":
         pp = _run(("powerprofilesctl", "get"), 4)
         return bool(pp and pp.returncode == 0 and (pp.stdout or "").strip() in {"balanced", "performance", "power-saver"})
@@ -970,22 +1057,33 @@ def check(
     user_initiated: bool = False,
     components: set[str] | frozenset[str] | None = None,
     recipe_ids: set[str] | frozenset[str] | None = None,
+    force_recipe_ids: set[str] | frozenset[str] | None = None,
+    persist: bool = True,
+    count_failures: bool | None = None,
 ) -> dict[str, Any]:
     config = load_config()
     state = load_state()
+    if count_failures is None:
+        count_failures = bool(persist) and not user_initiated
     symptoms = collect_symptoms()
     if components is not None:
         symptoms = [symptom for symptom in symptoms if symptom.component in components]
     active_components = {symptom.component for symptom in symptoms}
     occurrences = state.setdefault("occurrences", {})
-    for component in {recipe.component for recipe in RECIPES.values()}:
-        occurrences[component] = int(occurrences.get(component, 0)) + 1 if component in active_components else 0
+    if count_failures:
+        for component in {recipe.component for recipe in RECIPES.values()}:
+            occurrences[component] = int(occurrences.get(component, 0)) + 1 if component in active_components else 0
     decisions = [decision for symptom in symptoms if (decision := deterministic_decision(symptom))]
     ambiguous = [symptom for symptom in symptoms if deterministic_decision(symptom) is None]
     if investigate or ambiguous:
         model = infer(symptoms, state, force=investigate)
         if model:
             decisions.append(model)
+    if force_recipe_ids:
+        existing = {decision.recipe_id for decision in decisions}
+        for rid in force_recipe_ids:
+            if rid in RECIPES and rid not in existing:
+                decisions.append(Decision(rid, 1.0, "User requested this repair.", source="user"))
     if recipe_ids is not None:
         decisions = [decision for decision in decisions if decision.recipe_id in recipe_ids]
     apply = automatic or user_initiated
@@ -1021,11 +1119,13 @@ def check(
             "explanation": redact(decision.explanation), "action": action,
             "verified": verified, "detail": detail,
         }
-        state.setdefault("history", []).append(record)
+        if persist:
+            state.setdefault("history", []).append(record)
         results.append(record)
-    state["last_check"] = time.time()
-    _notify(results, config, state)
-    save_state(state)
+    if persist:
+        state["last_check"] = time.time()
+        _notify(results, config, state)
+        save_state(state)
     next_steps = []
     for record in results:
         recipe = RECIPES.get(str(record.get("recipe_id") or ""))
@@ -1043,13 +1143,24 @@ def check(
         "enabled": bool(config.get("enabled")),
         "automatic_safe_fixes": bool(config.get("automatic_safe_fixes")),
         "user_initiated": bool(user_initiated),
+        "persisted": bool(persist),
         "symptoms": [{**asdict(item), "evidence": redact(item.evidence)} for item in symptoms],
         "decisions": results,
         "next_steps": next_steps,
-        "pending": pending_recommendations(state),
+        "pending": pending_recommendations(state) if persist else pending_recommendations(),
         "model": model_status(),
         "suppression_reason": suppression_reason(),
     }
+
+
+def inspect(*, investigate: bool = False) -> dict[str, Any]:
+    """Read-only health snapshot. Does not write history, occurrences, or notifications."""
+    return check(
+        investigate=investigate,
+        automatic=False,
+        persist=False,
+        count_failures=False,
+    )
 
 
 def model_status() -> dict[str, Any]:
@@ -1071,7 +1182,8 @@ def status() -> dict[str, Any]:
             "pending_count": len(pending),
             "pending": [{"recipe_id": item.get("recipe_id"), "detail": item.get("detail", "")} for item in pending],
             "recipes": [{"id": recipe.id, "title": recipe.title, "risk": recipe.risk,
-                         "requires_auth": recipe.requires_auth, "automatic": recipe.automatic}
+                         "requires_auth": recipe.requires_auth, "automatic": recipe.automatic,
+                         "recovery": recipe.recovery}
                         for recipe in RECIPES.values()]}
 
 
@@ -1090,8 +1202,10 @@ def main(argv: list[str] | None = None) -> int:
     commands = parser.add_subparsers(dest="command", required=True)
     commands.add_parser("status")
     commands.add_parser("check")
+    commands.add_parser("inspect")
     commands.add_parser("investigate")
-    commands.add_parser("fix")
+    fix = commands.add_parser("fix")
+    fix.add_argument("recipe_id", nargs="*", help="optional recipe ids to apply immediately")
     commands.add_parser("history")
     commands.add_parser("enable")
     commands.add_parser("disable")
@@ -1104,13 +1218,27 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.command == "status":
             value = status()
+        elif args.command == "inspect":
+            value = inspect()
         elif args.command in {"check", "investigate"}:
             if not config["enabled"] and args.command == "check":
                 value = {"schema_version": SCHEMA_VERSION, "enabled": False, "skipped": True}
             else:
                 value = check(investigate=args.command == "investigate")
         elif args.command == "fix":
-            value = check(investigate=False, automatic=True, user_initiated=True)
+            requested = [rid for rid in (getattr(args, "recipe_id", None) or []) if rid]
+            unknown = [rid for rid in requested if rid not in RECIPES]
+            if unknown:
+                print(f"kyth-guardian: unknown recipe: {', '.join(unknown)}", file=sys.stderr)
+                return 1
+            ids = set(requested) or None
+            value = check(
+                investigate=False,
+                automatic=True,
+                user_initiated=True,
+                recipe_ids=ids,
+                force_recipe_ids=ids,
+            )
         elif args.command == "history":
             value = {"schema_version": SCHEMA_VERSION, "history": load_state().get("history", [])}
         elif args.command in {"enable", "disable"}:

--- a/src/kyth_shared/kyth_shared/guardian_actions.py
+++ b/src/kyth_shared/kyth_shared/guardian_actions.py
@@ -223,6 +223,43 @@ def restart_desktop_portals(run: Run) -> tuple[bool, str]:
     return False, "; ".join(notes) or "portal restart failed"
 
 
+def refresh_firmware_metadata(run: Run) -> tuple[bool, str]:
+    """Refresh LVFS metadata. Prefer the shared flock; fall back without it.
+
+    The user sandbox cannot create ``/run/kyth-fwupd.lock`` (ProtectSystem=strict).
+    fwupd's D-Bus daemon still serializes refresh, so skipping the lock is safe
+    when flock cannot open that path.
+    """
+    locked = run(("flock", "-w", "10", "/run/kyth-fwupd.lock", "fwupdmgr", "refresh", "--force"), 30)
+    if locked is not None and locked.returncode == 0:
+        return True, "firmware metadata refreshed"
+    plain = run(("fwupdmgr", "refresh", "--force"), 30)
+    if plain is not None and plain.returncode == 0:
+        return True, "firmware metadata refreshed"
+    err = ""
+    source = plain if plain is not None else locked
+    if source is not None:
+        err = (source.stderr or source.stdout or "").strip()[:200]
+    return False, err or "firmware metadata refresh failed"
+
+
+def run_storage_maintenance(run: Run) -> tuple[bool, str]:
+    """Run gated btrfs maintenance without a shell. Skip is not success."""
+    gate = run(("/usr/libexec/kyth-storage-gate",), 15)
+    if gate is None:
+        return False, "storage gate failed to start"
+    if gate.returncode != 0:
+        detail = (gate.stderr or gate.stdout or "").strip()[:200]
+        return False, detail or "storage maintenance gated (need idle + not gaming)"
+    maint = run(("/usr/bin/kyth-btrfs-maint",), 60)
+    if maint is None:
+        return False, "storage maintenance failed to start"
+    if maint.returncode != 0:
+        detail = (maint.stderr or maint.stdout or "").strip()[:200]
+        return False, detail or "storage maintenance failed"
+    return True, "storage maintenance started"
+
+
 ACTION_EXECUTORS: dict[str, Callable[[Run], tuple[bool, str]]] = {
     "display.reconfigure": apply_display_reconfigure,
     "audio.sink-fallback": restore_audio_sink,
@@ -232,4 +269,6 @@ ACTION_EXECUTORS: dict[str, Callable[[Run], tuple[bool, str]]] = {
     "network.vpn-fix": restore_autoconnect_vpn,
     "controller.repair": restart_joycond,
     "portal.restart-user": restart_desktop_portals,
+    "firmware.refresh": refresh_firmware_metadata,
+    "storage.maint": run_storage_maintenance,
 }

--- a/tests/test_kyth_guardian.py
+++ b/tests/test_kyth_guardian.py
@@ -145,7 +145,7 @@ class GuardianPolicyTests(unittest.TestCase):
         with (
             patch.object(guardian, "_active", return_value=False),
             patch.object(guardian.Path, "exists", return_value=True),
-            patch.object(guardian.Path, "iterdir", return_value=iter([pathlib.Path("/sys/class/bluetooth/hci0")])),
+            patch.object(guardian.Path, "iterdir", return_value=[pathlib.Path("/sys/class/bluetooth/hci0")]),
             patch.object(guardian, "_run", side_effect=_fake_run),
         ):
             syms = guardian.collect_symptoms()
@@ -517,12 +517,18 @@ class GuardianRobustnessTests(unittest.TestCase):
 
     def test_portal_probe_accepts_plasma_kde_unit_name(self):
         active = {"xdg-desktop-portal.service", "plasma-xdg-desktop-portal-kde.service"}
-        with patch.object(guardian, "_active", side_effect=lambda unit, user=False: unit in active):
+        with (
+            patch.object(guardian, "_active", side_effect=lambda unit, user=False: unit in active),
+            patch.object(guardian, "_unit_loaded", return_value=True),
+        ):
             self.assertEqual(guardian._probe_portal(), [])
 
     def test_portal_probe_flags_when_neither_kde_backend_active(self):
         active = {"xdg-desktop-portal.service"}
-        with patch.object(guardian, "_active", side_effect=lambda unit, user=False: unit in active):
+        with (
+            patch.object(guardian, "_active", side_effect=lambda unit, user=False: unit in active),
+            patch.object(guardian, "_unit_loaded", return_value=True),
+        ):
             symptoms = guardian._probe_portal()
         self.assertEqual(len(symptoms), 1)
         self.assertIn("plasma/xdg-desktop-portal-kde", symptoms[0].evidence)
@@ -554,6 +560,174 @@ class GuardianRobustnessTests(unittest.TestCase):
         self.assertIn("xdg-desktop-portal.service", restarted)
         self.assertIn("plasma-xdg-desktop-portal-kde.service", restarted)
         self.assertIn("xdg-desktop-portal-kde.service", restarted)
+
+
+class GuardianUsefulnessTests(unittest.TestCase):
+    def test_firmware_nothing_to_do_is_not_a_symptom(self):
+        fw_idle = subprocess.CompletedProcess(["fwupdmgr", "get-updates"], 2, stdout="No updates", stderr="")
+        with (
+            patch.object(guardian, "_active", return_value=True),
+            patch.object(guardian, "_run", side_effect=lambda argv, timeout=8: fw_idle if argv[0] == "fwupdmgr" else subprocess.CompletedProcess(argv, 0, "balanced\n", "")),
+            patch.object(guardian.shutil, "which", return_value=None),
+        ):
+            syms = guardian.collect_symptoms()
+        self.assertFalse(any(s.component == "firmware" for s in syms))
+
+    def test_tab_indented_kscreen_output_is_healthy(self):
+        kd_ok = subprocess.CompletedProcess(
+            ["kscreen-doctor", "-o"], 0,
+            stdout="Output: 1 eDP-1\n\tconnected\n\tenabled\n",
+            stderr="",
+        )
+        with patch.object(guardian, "_run", return_value=kd_ok), patch.object(guardian, "_in_graphical_session", return_value=True):
+            self.assertEqual(guardian._probe_display(), [])
+        with patch.object(guardian, "_run", return_value=kd_ok):
+            self.assertTrue(guardian.verify_recipe("display.reconfigure"))
+
+    def test_connected_disabled_output_is_a_display_symptom(self):
+        kd = subprocess.CompletedProcess(
+            ["kscreen-doctor", "-o"], 0,
+            stdout="Output: 1 HDMI-A-1\n\tconnected\n\tdisabled\nOutput: 2 eDP-1\n\tconnected\n\tenabled\n",
+            stderr="",
+        )
+        with patch.object(guardian, "_run", return_value=kd), patch.object(guardian, "_in_graphical_session", return_value=True):
+            symptoms = guardian._probe_display()
+        self.assertEqual(len(symptoms), 1)
+        self.assertEqual(symptoms[0].recipes, ("display.reconfigure",))
+        self.assertIn("HDMI-A-1", symptoms[0].evidence)
+
+    def test_bluetooth_without_adapter_is_not_a_symptom(self):
+        with (
+            patch.object(guardian, "_bluetooth_adapter_present", return_value=False),
+            patch.object(guardian, "_active", return_value=False),
+        ):
+            self.assertEqual(guardian._probe_bluetooth(), [])
+
+    def test_bluetooth_soft_blocked_is_not_a_symptom(self):
+        with (
+            patch.object(guardian, "_bluetooth_adapter_present", return_value=True),
+            patch.object(guardian, "_bluetooth_soft_blocked", return_value=True),
+            patch.object(guardian, "_active", return_value=False),
+        ):
+            self.assertEqual(guardian._probe_bluetooth(), [])
+
+    def test_custom_power_profile_is_not_a_fault(self):
+        quiet = subprocess.CompletedProcess(["powerprofilesctl", "get"], 0, stdout="quiet\n", stderr="")
+        with patch.object(guardian, "_run", return_value=quiet):
+            self.assertEqual(guardian._probe_power(), [])
+
+    def test_inspect_does_not_persist_history_or_occurrences(self):
+        audio = guardian.Symptom("audio", "down", ("audio.restart",))
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            patch.dict(os.environ, {"XDG_STATE_HOME": temp, "XDG_CONFIG_HOME": temp}, clear=False),
+            patch.object(guardian, "collect_symptoms", return_value=[audio]),
+            patch.object(guardian, "suppression_reason", return_value=""),
+        ):
+            before = guardian.load_state()
+            result = guardian.inspect()
+            after = guardian.load_state()
+        self.assertTrue(result["symptoms"])
+        self.assertFalse(result.get("persisted", True))
+        self.assertEqual(after.get("history"), before.get("history"))
+        self.assertEqual(after.get("occurrences"), before.get("occurrences"))
+
+    def test_run_check_does_not_count_failures_toward_autofix(self):
+        audio = guardian.Symptom("audio", "down", ("audio.restart",))
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            patch.dict(os.environ, {"XDG_STATE_HOME": temp, "XDG_CONFIG_HOME": temp}, clear=False),
+            patch.object(guardian, "collect_symptoms", return_value=[audio]),
+            patch.object(guardian, "suppression_reason", return_value=""),
+            patch.object(guardian, "load_config", return_value={
+                "enabled": True, "automatic_safe_fixes": True, "notifications": False,
+            }),
+        ):
+            guardian.check(automatic=False, persist=True, count_failures=False)
+            state = guardian.load_state()
+        self.assertEqual(int(state.get("occurrences", {}).get("audio", 0)), 0)
+        self.assertTrue(state.get("history"))
+
+    def test_force_recipe_applies_without_matching_symptom(self):
+        with (
+            patch.object(guardian, "collect_symptoms", return_value=[]),
+            patch.object(guardian, "load_config", return_value={
+                "enabled": True, "automatic_safe_fixes": False, "notifications": False,
+            }),
+            patch.object(guardian, "load_state", return_value={"occurrences": {}, "history": []}),
+            patch.object(guardian, "save_state"),
+            patch.object(guardian, "execute_recipe", return_value=(True, "ok")) as execute,
+            patch.object(guardian, "verify_recipe", return_value=True),
+            patch.object(guardian, "suppression_reason", return_value=""),
+        ):
+            result = guardian.check(
+                automatic=True,
+                user_initiated=True,
+                recipe_ids={"audio.restart"},
+                force_recipe_ids={"audio.restart"},
+            )
+        execute.assert_called_once_with("audio.restart", user_initiated=True)
+        self.assertEqual(result["decisions"][0]["action"], "executed")
+
+    def test_timer_cannot_auto_run_storage_maint(self):
+        decision = guardian.Decision("storage.maint", 1, "known")
+        with patch.object(guardian, "suppression_reason", return_value=""):
+            allowed, reason = guardian.can_execute(
+                decision, {"automatic_safe_fixes": True},
+                {"history": [], "occurrences": {"storage": 2}},
+            )
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "confirmation required")
+        with patch.object(guardian, "suppression_reason", return_value=""):
+            allowed, _ = guardian.can_execute(
+                decision, {"automatic_safe_fixes": False},
+                {"history": [], "occurrences": {}}, user_initiated=True,
+            )
+        self.assertTrue(allowed)
+
+    def test_firmware_refresh_falls_back_without_system_lock(self):
+        from kyth_shared.guardian_actions import refresh_firmware_metadata
+
+        def _run(argv, timeout=8):
+            if argv[0] == "flock":
+                return subprocess.CompletedProcess(argv, 1, "", "cannot open lock")
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        ok, detail = refresh_firmware_metadata(_run)
+        self.assertTrue(ok)
+        self.assertIn("refreshed", detail)
+
+    def test_storage_maint_executor_does_not_use_a_shell(self):
+        from kyth_shared.guardian_actions import run_storage_maintenance
+
+        calls: list[tuple] = []
+
+        def _run(argv, timeout=8):
+            calls.append(tuple(argv))
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        ok, _detail = run_storage_maintenance(_run)
+        self.assertTrue(ok)
+        self.assertEqual(calls[0], ("/usr/libexec/kyth-storage-gate",))
+        self.assertEqual(calls[1], ("/usr/bin/kyth-btrfs-maint",))
+
+    def test_cli_inspect_and_targeted_fix(self):
+        with (
+            patch.object(guardian, "inspect", return_value={"persisted": False}) as inspect,
+            patch.object(guardian, "check", return_value={"ok": True}) as check,
+            patch.object(guardian, "load_config", return_value={"enabled": True}),
+        ):
+            self.assertEqual(guardian.main(["inspect"]), 0)
+            inspect.assert_called_once_with()
+            self.assertEqual(guardian.main(["fix", "audio.restart"]), 0)
+            check.assert_called_once()
+            kwargs = check.call_args.kwargs
+            self.assertTrue(kwargs["user_initiated"])
+            self.assertEqual(kwargs["force_recipe_ids"], {"audio.restart"})
+
+    def test_cli_fix_rejects_unknown_recipe(self):
+        with patch.object(guardian, "load_config", return_value={"enabled": True}):
+            self.assertEqual(guardian.main(["fix", "shell.run"]), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_kyth_system_service_hardening.py
+++ b/tests/test_kyth_system_service_hardening.py
@@ -70,7 +70,11 @@ class SystemServiceHardeningTests(unittest.TestCase):
                 with self.subTest(unit=unit_name, directive=directive):
                     self.assertIn(directive, body)
 
-    def test_network_installer_and_read_only_probe_use_strict_filesystems(self) -> None:
+    def test_guardian_user_unit_can_persist_state(self) -> None:
+        body = (ROOT / "build_files/kyth-guardian.service").read_text(encoding="utf-8")
+        self.assertIn("StateDirectory=kyth", body)
+        self.assertIn("ProtectSystem=strict", body)
+        self.assertIn("ReadWritePaths=-%h/.local/share/flatpak", body)
         proton = (ROOT / "build_files/kyth-proton-cachyos-update.service").read_text()
         probe = (ROOT / "build_files/kyth-probe.service").read_text()
         self.assertIn("ProtectSystem=strict", proton)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this change?

Guardian was designed as Kyth's bounded self-heal, but the background timer could not persist state and the Hub page mostly watched instead of repairing.

`ProtectSystem=strict` on `kyth-guardian.service` made the whole filesystem read-only and there was no `StateDirectory`, so `~/.local/state/kyth/guardian.json` never survived a timer run. Occurrence counters reset every 15 minutes, so auto-fix could never reach the two-consecutive-failure gate. Opening System → Guardian also called `check()`, which counted as failures, wrote history, and could fire notifications.

This change:

- Gives the user oneshot `StateDirectory=kyth` plus Flatpak `--user` write paths so timer checks and `flatpak.refresh-metadata` can actually succeed.
- Adds `inspect()` / `kyth-guardian inspect` as a read-only snapshot. Live health uses that; opening the page no longer accelerates auto-fix.
- Stops common false positives: `fwupdmgr get-updates` exit 2 (nothing to do), kscreen-doctor tab-indented healthy output, Bluetooth with no adapter or rfkill soft-block, and vendor power-profile names.
- Makes the Hub page do the job: per-symptom **Apply**, human history with Yes/No feedback, `kyth-guardian fix <recipe-id>` for a single allowlisted repair.
- Keeps storage maintenance off the 90s timer (a scrub cannot finish there); Fix My System can still run it. Firmware refresh falls back when `/run/kyth-fwupd.lock` is not writable in the sandbox.

Safety boundary is unchanged: allowlist-only, model still cannot invent commands, auto-fix still needs two timer hits + cooldown + no gaming/thermal/update suppression.

## How was it tested?

- `python3 -m unittest tests.test_kyth_guardian tests.test_kyth_system_service_hardening -v` — 59 tests, all passing (new coverage for inspect persistence, firmware/display/bluetooth/power probes, targeted `fix`, storage executor, service `StateDirectory`).
- Full `unittest discover -s tests` was run; the only failure is pre-existing `test_kyth_probe_cache.ProbeCacheFileTests.test_stale_section_rejected` (unrelated probe TTL, not touched here).
- `python3 -m py_compile` on the modified Guardian modules.

The systemd unit change takes effect on the next image that ships `kyth-guardian.service`. On a running system, `systemctl --user daemon-reload` after updating that unit is enough for the timer path; Hub Apply/Fix My System already run outside the sandbox.

## Checklist

- [x] `just lint` passes (shellcheck + shfmt) — no shell scripts changed
- [ ] `python3 -m unittest discover -s tests` passes — Guardian tests pass; one pre-existing probe-cache failure remains
- [ ] Changes to build scripts tested with `just build` or `just build-live-iso` — unit file only, no image build in this environment
- [x] Major behavior changes include automated tests or a documented rationale
- [ ] New packages or COPRs justified in the PR description
- [ ] Breaking changes to the installer or upgrade path noted above — CLI gains `inspect` and optional `fix <recipe-id>`; existing `status|check|fix|history` remain
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12dfd767-fb71-4142-9724-d16d9c63c691?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12dfd767-fb71-4142-9724-d16d9c63c691&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

