### PR TITLE
fix(ci): start image builds at Validation and skip unchanged bases

### DIFF
--- a/.github/workflows/build-live-iso.yml
+++ b/.github/workflows/build-live-iso.yml
@@ -5,14 +5,10 @@ on:
   # Separate from container build — ISO failures no longer hide successful
   # container publishes. build.yml's finalize job dispatches this explicitly
   # (workflow_dispatch, pinned digest) once the Fedora image actually
-  # publishes. There is deliberately no workflow_run trigger here: build.yml's
-  # own Validation+CodeQL gate fires "Build container image" twice per push
-  # (once per watched workflow) and the first of the two — before both checks
-  # have reported in — completes with every job skipped, which GitHub still
-  # reports as an overall success. A workflow_run listener can't tell that
-  # apart from a real publish, so it fired a doomed ISO build racing the
-  # actual one on every push. The explicit dispatch only ever fires from the
-  # leg that did real work.
+  # publishes. There is deliberately no workflow_run trigger here: a
+  # workflow_run listener cannot tell a skipped/gated image run from a real
+  # publish, and previously fired a doomed ISO build racing the actual one.
+  # The explicit dispatch only ever fires from the leg that did real work.
   workflow_call:
     inputs:
       source_tag:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     - cron: '05 10 * * 0' # 10:05am UTC weekly on Sundays — rebuilds both :latest and :testing with fresh upstream packages
   workflow_dispatch:
   workflow_run: # zizmor: ignore[dangerous-triggers]
-    workflows: ["Validation", "CodeQL"]
+    workflows: ["Validation"]
     types: [completed]
     branches: [main, testing]
 
@@ -22,7 +22,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   gate:
-    name: Gate on Validation + CodeQL
+    name: Gate on Validation
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -34,7 +34,7 @@ jobs:
       head_sha: ${{ steps.check.outputs.head_sha }}
       head_branch: ${{ steps.check.outputs.head_branch }}
     steps:
-      - name: Verify Validation and CodeQL succeeded for SHA
+      - name: Verify Validation succeeded for SHA
         id: check
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -68,26 +68,14 @@ jobs:
             const headBranch = run.head_branch;
             core.setOutput('head_sha', headSha);
             core.setOutput('head_branch', headBranch);
-            // Require both Validation and CodeQL to be successful for this SHA.
-            // The build is triggered twice (once per workflow); only the second
-            // to complete will see both as success and proceed.
-            const required = ['Validation', 'CodeQL'];
-            for (const wfName of required) {
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: wfName === 'Validation' ? 'validation.yml' : 'codeql.yml',
-                head_sha: headSha,
-                per_page: 5,
-              });
-              const ok = runs.data.workflow_runs.some(r => r.conclusion === 'success' && r.head_branch === headBranch);
-              if (!ok) {
-                core.info(`Waiting for ${wfName} success on ${headSha} (${headBranch}) — not yet`);
-                core.setOutput('ok', 'false');
-                return;
-              }
+            // Image builds start when Validation succeeds. CodeQL still runs on
+            // the push as a parallel check and no longer blocks :testing/:latest.
+            if (run.name !== 'Validation') {
+              core.info(`Ignoring unexpected workflow_run from ${run.name}`);
+              core.setOutput('ok', 'false');
+              return;
             }
-            core.info(`Both Validation and CodeQL succeeded for ${headSha} — proceeding`);
+            core.info(`Validation succeeded for ${headSha} (${headBranch}) — proceeding`);
             core.setOutput('ok', 'true');
 
   plan:
@@ -117,7 +105,7 @@ jobs:
           if [[ "${EVENT_NAME}" == schedule ]]; then
             echo 'branches=["main","testing"]' >&3
           elif [[ "${EVENT_NAME}" == workflow_run && -n "${HEAD_BRANCH}" ]]; then
-            # Gated via Validation/CodeQL — build the exact branch that was validated
+            # Gated via Validation — build the exact branch that was validated
             # (workflow_run's head_branch, not the default branch)
             echo "branches=[\"${HEAD_BRANCH}\"]" >&3
             echo "head_sha=${HEAD_SHA}" >&3 || true
@@ -169,7 +157,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # For gated workflow_run, check out the exact SHA that Validation/CodeQL
+          # For gated workflow_run, check out the exact SHA that Validation
           # approved; otherwise fall back to the branch tip (schedule/dispatch)
           ref: ${{ needs.plan.outputs.head_sha || matrix.branch }}
           persist-credentials: false
@@ -294,14 +282,34 @@ jobs:
           IMAGE_FULL="ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}"
           BASE_CACHE_REF="${IMAGE_FULL}:buildcache-base-${MATRIX_BRANCH}-${MATRIX_KERNEL_FLAVOR}"
           BASE_IMAGE_REF="${IMAGE_FULL}:base-${STEPS_PREP_OUTPUTS_DEFAULT_TAG}"
+          BASE_SRC_HASH="$(python3 build_files/scripts/reuse-base-image.py hash --source-root build_base)"
+          DECISION="$(python3 build_files/scripts/reuse-base-image.py decide \
+            --ref "${BASE_IMAGE_REF}" \
+            --upstream "${STEPS_UPSTREAM_BASE_OUTPUTS_PINNED}" \
+            --flavor "${MATRIX_KERNEL_FLAVOR}" \
+            --kernel "${CACHYOS_KERNEL_VERSION}" \
+            --source-root build_base)"
+          echo "::notice::base reuse decision ${DECISION}"
+
+          if [[ "$(jq -r '.reuse' <<<"${DECISION}")" == "true" ]]; then
+            BASE_DIGEST="$(jq -r '.digest' <<<"${DECISION}")"
+            build_files/scripts/validate-digest.sh "${BASE_DIGEST}"
+            echo "image=${BASE_IMAGE_REF}" >&3
+            echo "digest=${BASE_DIGEST}" >&3
+            echo "pinned=${BASE_IMAGE_REF}@${BASE_DIGEST}" >&3
+            echo "reused=true" >&3
+            exit 0
+          fi
 
           docker buildx build \
             --build-arg BASE_IMAGE="${STEPS_UPSTREAM_BASE_OUTPUTS_PINNED}" \
             --build-arg KYTH_KERNEL_FLAVOR="${MATRIX_KERNEL_FLAVOR}" \
             --build-arg CACHYOS_KERNEL_VER="${CACHYOS_KERNEL_VERSION}" \
-            --cache-from "type=gha,scope=base-${MATRIX_BRANCH}-${MATRIX_KERNEL_FLAVOR}" \
+            --label "org.kyth.build.upstream-base=${STEPS_UPSTREAM_BASE_OUTPUTS_PINNED}" \
+            --label "org.kyth.build.kernel-flavor=${MATRIX_KERNEL_FLAVOR}" \
+            --label "org.kyth.build.cachyos-kernel-version=${CACHYOS_KERNEL_VERSION}" \
+            --label "org.kyth.build.base-src-hash=${BASE_SRC_HASH}" \
             --cache-from "type=registry,ref=${BASE_CACHE_REF}" \
-            --cache-to "type=gha,scope=base-${MATRIX_BRANCH}-${MATRIX_KERNEL_FLAVOR},mode=max" \
             --cache-to "type=registry,ref=${BASE_CACHE_REF},mode=max" \
             --tag "${BASE_IMAGE_REF}" \
             --metadata-file "${RUNNER_TEMP}/base-build-metadata.json" \
@@ -313,6 +321,7 @@ jobs:
           echo "image=${BASE_IMAGE_REF}" >&3
           echo "digest=${BASE_DIGEST}" >&3
           echo "pinned=${BASE_IMAGE_REF}@${BASE_DIGEST}" >&3
+          echo "reused=false" >&3
         env:
           MATRIX_BRANCH: ${{ matrix.branch }}
           MATRIX_KERNEL_FLAVOR: ${{ matrix.kernel_flavor }}
@@ -386,9 +395,7 @@ jobs:
             --build-arg ENABLE_KSM=0 \
             --build-arg BUILD_DATE="$(date +%Y-%m-%d)" \
             --build-arg SECUREBOOT_SIGNING_REQUESTED="${SECUREBOOT_SIGNING_REQUESTED}" \
-            --cache-from "type=gha,scope=final-${MATRIX_BRANCH}-${MATRIX_KERNEL_FLAVOR}" \
             --cache-from "type=registry,ref=${FINAL_CACHE_REF}" \
-            --cache-to "type=gha,scope=final-${MATRIX_BRANCH}-${MATRIX_KERNEL_FLAVOR},mode=max" \
             --cache-to "type=registry,ref=${FINAL_CACHE_REF},mode=max" \
             --tag "${RAW_IMAGE_REF}" \
             "${LABEL_ARGS[@]}" \

--- a/build_files/scripts/reuse-base-image.py
+++ b/build_files/scripts/reuse-base-image.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Decide whether CI can reuse a published Kyth base image.
+
+Inspects an existing GHCR ``base-${tag}`` ref and compares
+``org.kyth.build.*`` labels against the current build inputs. A missing
+tag or an unlabeled image (every base published before this helper)
+forces a rebuild.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+LABEL_UPSTREAM = "org.kyth.build.upstream-base"
+LABEL_FLAVOR = "org.kyth.build.kernel-flavor"
+LABEL_KERNEL = "org.kyth.build.cachyos-kernel-version"
+LABEL_SRC = "org.kyth.build.base-src-hash"
+REQUIRED_LABELS = (LABEL_UPSTREAM, LABEL_FLAVOR, LABEL_KERNEL, LABEL_SRC)
+
+
+def source_hash(source_root: Path) -> str:
+    """Stable sha256 of every regular file under ``source_root``."""
+    root = source_root.resolve()
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        relative = path.relative_to(root).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _walk_keys(payload: Any, keys: tuple[str, ...]) -> Any:
+    current = payload
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def extract_digest(payload: dict[str, Any]) -> str | None:
+    for path in (
+        ("manifest", "digest"),
+        ("Descriptor", "digest"),
+        ("descriptor", "digest"),
+        ("digest",),
+    ):
+        value = _walk_keys(payload, path)
+        if isinstance(value, str) and value.startswith("sha256:"):
+            return value
+    return None
+
+
+def extract_labels(payload: dict[str, Any]) -> dict[str, str]:
+    images = [payload.get("image"), payload.get("Image"), payload]
+    for image in images:
+        if not isinstance(image, dict):
+            continue
+        config = image.get("config") or image.get("Config") or {}
+        if not isinstance(config, dict):
+            continue
+        labels = config.get("Labels") or config.get("labels") or {}
+        if isinstance(labels, dict) and labels:
+            return {str(key): str(value) for key, value in labels.items() if value is not None}
+    return {}
+
+
+def decide_reuse(
+    *,
+    labels: dict[str, str],
+    digest: str | None,
+    upstream: str,
+    flavor: str,
+    kernel: str,
+    src_hash: str,
+) -> dict[str, Any]:
+    expected = {
+        LABEL_UPSTREAM: upstream,
+        LABEL_FLAVOR: flavor,
+        LABEL_KERNEL: kernel,
+        LABEL_SRC: src_hash,
+    }
+    missing = [key for key in REQUIRED_LABELS if key not in labels]
+    if missing:
+        return {"reuse": False, "digest": digest, "reason": "missing-labels"}
+    mismatches = [key for key, value in expected.items() if labels.get(key) != value]
+    if mismatches:
+        return {"reuse": False, "digest": digest, "reason": "label-mismatch"}
+    if not digest or not digest.startswith("sha256:"):
+        return {"reuse": False, "digest": digest, "reason": "missing-digest"}
+    return {"reuse": True, "digest": digest, "reason": "match"}
+
+
+def inspect_ref(ref: str) -> dict[str, Any] | None:
+    try:
+        result = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", ref, "--format", "{{ json . }}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def cmd_hash(args: argparse.Namespace) -> int:
+    print(source_hash(args.source_root))
+    return 0
+
+
+def cmd_decide(args: argparse.Namespace) -> int:
+    src_hash = source_hash(args.source_root)
+    payload = inspect_ref(args.ref)
+    if payload is None:
+        print(json.dumps({"reuse": False, "digest": None, "reason": "inspect-failed"}))
+        return 0
+    decision = decide_reuse(
+        labels=extract_labels(payload),
+        digest=extract_digest(payload),
+        upstream=args.upstream,
+        flavor=args.flavor,
+        kernel=args.kernel,
+        src_hash=src_hash,
+    )
+    print(json.dumps(decision))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    hash_parser = sub.add_parser("hash", help="Print sha256 of build_base sources")
+    hash_parser.add_argument("--source-root", type=Path, required=True)
+    hash_parser.set_defaults(func=cmd_hash)
+
+    decide_parser = sub.add_parser("decide", help="Inspect a published base tag")
+    decide_parser.add_argument("--ref", required=True)
+    decide_parser.add_argument("--upstream", required=True)
+    decide_parser.add_argument("--flavor", required=True)
+    decide_parser.add_argument("--kernel", required=True)
+    decide_parser.add_argument("--source-root", type=Path, required=True)
+    decide_parser.set_defaults(func=cmd_decide)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kyth_build_profiles.py
+++ b/tests/test_kyth_build_profiles.py
@@ -110,6 +110,21 @@ class BuildProfileTests(unittest.TestCase):
         # And the ISO workflow must not silently publish without a source image
         self.assertIn("source_tag", iso)
 
+    def test_image_build_gates_on_validation_only(self):
+        workflow = _read(".github/workflows/build.yml")
+        iso = _read(".github/workflows/build-live-iso.yml")
+        self.assertIn('workflows: ["Validation"]', workflow)
+        self.assertNotIn('workflows: ["Validation", "CodeQL"]', workflow)
+        self.assertNotIn("const required = ['Validation', 'CodeQL']", workflow)
+        self.assertNotIn("workflow_run:", iso.split("jobs:", 1)[0])
+
+    def test_image_build_writes_registry_cache_only(self):
+        workflow = _read(".github/workflows/build.yml")
+        self.assertNotIn("type=gha", workflow)
+        self.assertIn('--cache-from "type=registry,ref=', workflow)
+        self.assertIn('--cache-to "type=registry,ref=', workflow)
+        self.assertIn("mode=max", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kyth_reuse_base_image.py
+++ b/tests/test_kyth_reuse_base_image.py
@@ -1,0 +1,151 @@
+"""Unit tests for reuse-base-image.py — match / mismatch / missing labels."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "reuse_base_image", ROOT / "build_files" / "scripts" / "reuse-base-image.py"
+)
+assert SPEC and SPEC.loader
+reuse_base_image = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(reuse_base_image)
+
+
+DIGEST = "sha256:" + ("a" * 64)
+
+
+def _inspect_payload(labels: dict[str, str] | None = None, digest: str = DIGEST) -> dict:
+    return {
+        "manifest": {"digest": digest},
+        "image": {"config": {"Labels": labels or {}}},
+    }
+
+
+class SourceHashTests(unittest.TestCase):
+    def test_hash_is_stable_for_the_same_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+            (root / "build.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+            first = reuse_base_image.source_hash(root)
+            second = reuse_base_image.source_hash(root)
+        self.assertEqual(first, second)
+        self.assertEqual(64, len(first))
+
+    def test_hash_changes_when_a_file_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "Dockerfile"
+            path.write_text("FROM scratch\n", encoding="utf-8")
+            before = reuse_base_image.source_hash(root)
+            path.write_text("FROM alpine\n", encoding="utf-8")
+            after = reuse_base_image.source_hash(root)
+        self.assertNotEqual(before, after)
+
+
+class InspectParseTests(unittest.TestCase):
+    def test_extracts_digest_and_labels_from_buildx_json(self):
+        payload = _inspect_payload(
+            {
+                reuse_base_image.LABEL_UPSTREAM: "ghcr.io/ublue-os/kinoite-main:44@sha256:" + ("b" * 64),
+                reuse_base_image.LABEL_FLAVOR: "cachy",
+            }
+        )
+        self.assertEqual(DIGEST, reuse_base_image.extract_digest(payload))
+        labels = reuse_base_image.extract_labels(payload)
+        self.assertEqual("cachy", labels[reuse_base_image.LABEL_FLAVOR])
+
+
+class DecideReuseTests(unittest.TestCase):
+    def _expected(self) -> dict[str, str]:
+        return {
+            reuse_base_image.LABEL_UPSTREAM: "upstream@sha256:" + ("b" * 64),
+            reuse_base_image.LABEL_FLAVOR: "fedora",
+            reuse_base_image.LABEL_KERNEL: "unused",
+            reuse_base_image.LABEL_SRC: "c" * 64,
+        }
+
+    def test_match_reuses_the_digest(self):
+        labels = self._expected()
+        decision = reuse_base_image.decide_reuse(
+            labels=labels,
+            digest=DIGEST,
+            upstream=labels[reuse_base_image.LABEL_UPSTREAM],
+            flavor="fedora",
+            kernel="unused",
+            src_hash=labels[reuse_base_image.LABEL_SRC],
+        )
+        self.assertEqual({"reuse": True, "digest": DIGEST, "reason": "match"}, decision)
+
+    def test_missing_labels_rebuild(self):
+        decision = reuse_base_image.decide_reuse(
+            labels={},
+            digest=DIGEST,
+            upstream="upstream",
+            flavor="fedora",
+            kernel="unused",
+            src_hash="abc",
+        )
+        self.assertEqual(False, decision["reuse"])
+        self.assertEqual("missing-labels", decision["reason"])
+
+    def test_label_mismatch_rebuilds(self):
+        labels = self._expected()
+        decision = reuse_base_image.decide_reuse(
+            labels=labels,
+            digest=DIGEST,
+            upstream=labels[reuse_base_image.LABEL_UPSTREAM],
+            flavor="cachy",
+            kernel="unused",
+            src_hash=labels[reuse_base_image.LABEL_SRC],
+        )
+        self.assertEqual(False, decision["reuse"])
+        self.assertEqual("label-mismatch", decision["reason"])
+
+    def test_missing_digest_rebuilds_even_when_labels_match(self):
+        labels = self._expected()
+        decision = reuse_base_image.decide_reuse(
+            labels=labels,
+            digest=None,
+            upstream=labels[reuse_base_image.LABEL_UPSTREAM],
+            flavor="fedora",
+            kernel="unused",
+            src_hash=labels[reuse_base_image.LABEL_SRC],
+        )
+        self.assertEqual(False, decision["reuse"])
+        self.assertEqual("missing-digest", decision["reason"])
+
+
+class DecideCommandTests(unittest.TestCase):
+    def test_inspect_failure_prints_rebuild_decision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+            stdout = StringIO()
+            args = mock.Mock(
+                source_root=root,
+                ref="ghcr.io/example/kyth:base-testing",
+                upstream="upstream",
+                flavor="fedora",
+                kernel="unused",
+            )
+            with mock.patch.object(reuse_base_image, "inspect_ref", return_value=None), mock.patch(
+                "sys.stdout", stdout
+            ):
+                exit_code = reuse_base_image.cmd_decide(args)
+        self.assertEqual(0, exit_code)
+        self.assertEqual(
+            {"reuse": False, "digest": None, "reason": "inspect-failed"},
+            json.loads(stdout.getvalue()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Drop the CodeQL image gate and the extra no-op workflow_run. Write BuildKit cache to GHCR only. Reuse a published base-* digest when its labels still match upstream, kernel pin, and build_base sources.

## What does this change?

<!-- One or two sentences. What problem does it solve or what does it add? -->

## How was it tested?

<!-- How did you verify the change works? e.g. local build, booted ISO, checked a game, ran just lint -->

## Checklist

- [ ] `just lint` passes (shellcheck + shfmt)
- [ ] `python3 -m unittest discover -s tests` passes
- [ ] Changes to build scripts tested with `just build` or `just build-live-iso`
- [ ] Major behavior changes include automated tests or a documented rationale
- [ ] New packages or COPRs justified in the PR description
- [ ] Breaking changes to the installer or upgrade path noted above
